### PR TITLE
Add PLC enums for connection, memory, and device types

### DIFF
--- a/src/OmronPlcRx/Enums/ConnectionMethod.cs
+++ b/src/OmronPlcRx/Enums/ConnectionMethod.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Enums;
+
+/// <summary>
+/// Transport protocol used for communication with the PLC.
+/// </summary>
+public enum ConnectionMethod
+{
+    /// <summary>
+    /// Transmission Control Protocol.
+    /// </summary>
+    TCP,
+
+    /// <summary>
+    /// User Datagram Protocol.
+    /// </summary>
+    UDP,
+}

--- a/src/OmronPlcRx/Enums/MemoryBitDataType.cs
+++ b/src/OmronPlcRx/Enums/MemoryBitDataType.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Enums;
+
+/// <summary>
+/// Bit-addressable PLC memory areas.
+/// </summary>
+public enum MemoryBitDataType : byte
+{
+    /// <summary>
+    /// Data memory area (DM).
+    /// </summary>
+    DataMemory = 0x2,
+
+    /// <summary>
+    /// Common I/O area (CIO).
+    /// </summary>
+    CommonIO = 0x30,
+
+    /// <summary>
+    /// Work area (W).
+    /// </summary>
+    Work = 0x31,
+
+    /// <summary>
+    /// Holding area (H).
+    /// </summary>
+    Holding = 0x32,
+
+    /// <summary>
+    /// Auxiliary area (A).
+    /// </summary>
+    Auxiliary = 0x33,
+}

--- a/src/OmronPlcRx/Enums/MemoryWordDataType.cs
+++ b/src/OmronPlcRx/Enums/MemoryWordDataType.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Enums;
+
+/// <summary>
+/// Word-addressable PLC memory areas.
+/// </summary>
+public enum MemoryWordDataType : byte
+{
+    /// <summary>
+    /// Data memory area (DM).
+    /// </summary>
+    DataMemory = 0x82,
+
+    /// <summary>
+    /// Common I/O area (CIO).
+    /// </summary>
+    CommonIO = 0xB0,
+
+    /// <summary>
+    /// Work area (W).
+    /// </summary>
+    Work = 0xB1,
+
+    /// <summary>
+    /// Holding area (H).
+    /// </summary>
+    Holding = 0xB2,
+
+    /// <summary>
+    /// Auxiliary area (A).
+    /// </summary>
+    Auxiliary = 0xB3,
+}

--- a/src/OmronPlcRx/Enums/PLCType.cs
+++ b/src/OmronPlcRx/Enums/PLCType.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Enums;
+
+/// <summary>
+/// Supported Omron PLC types used to adjust message capabilities and limits.
+/// </summary>
+public enum PLCType
+{
+    /// <summary>
+    /// Omron NJ101 series.
+    /// </summary>
+    NJ101,
+
+    /// <summary>
+    /// Omron NJ301 series.
+    /// </summary>
+    NJ301,
+
+    /// <summary>
+    /// Omron NJ501 series.
+    /// </summary>
+    NJ501,
+
+    /// <summary>
+    /// Omron NX1P2 series.
+    /// </summary>
+    NX1P2,
+
+    /// <summary>
+    /// Omron NX102 series.
+    /// </summary>
+    NX102,
+
+    /// <summary>
+    /// Omron NX701 series.
+    /// </summary>
+    NX701,
+
+    /// <summary>
+    /// Omron NY512 series.
+    /// </summary>
+    NY512,
+
+    /// <summary>
+    /// Omron NY532 series.
+    /// </summary>
+    NY532,
+
+    /// <summary>
+    /// Generic NJ/NX/NY series.
+    /// </summary>
+    NJ_NX_NY_Series,
+
+    /// <summary>
+    /// Omron CJ2 series.
+    /// </summary>
+    CJ2,
+
+    /// <summary>
+    /// Omron CP1 series.
+    /// </summary>
+    CP1,
+
+    /// <summary>
+    /// Omron C-series (legacy).
+    /// </summary>
+    C_Series,
+
+    /// <summary>
+    /// Unknown or not yet identified.
+    /// </summary>
+    Unknown,
+}


### PR DESCRIPTION
Introduced enums for ConnectionMethod, MemoryBitDataType, MemoryWordDataType, and PLCType in the OmronPlcRx.Enums namespace. These enums define supported transport protocols, bit/word-addressable memory areas, and Omron PLC device types to standardize communication and memory addressing.