### PR TITLE
Add FINS protocol request classes for Omron PLC

### DIFF
--- a/src/OmronPlcRx/Core/Requests/FINSRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/FINSRequest.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Channels;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal abstract class FINSRequest
+{
+    internal const int HeaderLength = 10;
+    internal const int CommandLength = 2;
+
+    protected FINSRequest(OmronPLC plc)
+    {
+        if (plc.Channel is TCPChannel)
+        {
+            LocalNodeID = (plc.Channel as TCPChannel).LocalNodeID;
+            RemoteNodeID = (plc.Channel as TCPChannel).RemoteNodeID;
+        }
+        else
+        {
+            LocalNodeID = plc.LocalNodeID;
+            RemoteNodeID = plc.RemoteNodeID;
+        }
+    }
+
+    internal byte LocalNodeID { get; }
+
+    internal byte RemoteNodeID { get; }
+
+    internal byte ServiceID { get; set; }
+
+    internal byte FunctionCode { get; set; }
+
+    internal byte SubFunctionCode { get; set; }
+
+    internal ReadOnlyMemory<byte> BuildMessage(byte requestId)
+    {
+        ServiceID = requestId;
+
+        var message = new List<byte>
+        {
+            // Information Control Field
+            0x80,
+
+            // Reserved by System
+            0,
+
+            // Permissible Number of Gateways
+            0x02,
+
+            // Destination Network Address
+            0, // Local Network
+
+            // Destination Node Address
+            // 0 = Local PLC Unit
+            // 1 to 254 = Destination Node Address
+            // 255 = Broadcasting
+            RemoteNodeID,
+
+            // Destination Unit Address
+            0, // PLC (CPU Unit)
+
+            // Source Network Address
+            0, // Local Network
+
+            // Source Node Address
+            LocalNodeID, // Local Server
+
+            // Source Unit Address
+            0,
+
+            // Service ID
+            ServiceID,
+
+            // Main Function Code
+            FunctionCode,
+
+            // Sub Function Code
+            SubFunctionCode
+        };
+
+        // Request Data
+        message.AddRange(BuildRequestData());
+
+        return new ReadOnlyMemory<byte>([.. message]);
+    }
+
+    protected abstract List<byte> BuildRequestData();
+}

--- a/src/OmronPlcRx/Core/Requests/ReadCPUUnitDataRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadCPUUnitDataRequest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class ReadCPUUnitDataRequest : FINSRequest
+{
+    private ReadCPUUnitDataRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal static ReadCPUUnitDataRequest CreateNew(OmronPLC plc) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.MachineConfiguration,
+        SubFunctionCode = (byte)MachineConfigurationFunctionCode.ReadCPUUnitData,
+    };
+
+    protected override List<byte> BuildRequestData() =>
+        [
+            0
+        ];
+}

--- a/src/OmronPlcRx/Core/Requests/ReadClockRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadClockRequest.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class ReadClockRequest : FINSRequest
+{
+    private ReadClockRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal static ReadClockRequest CreateNew(OmronPLC plc) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.TimeData,
+        SubFunctionCode = (byte)TimeDataFunctionCode.ReadClock,
+    };
+
+    protected override List<byte> BuildRequestData() => new();
+}

--- a/src/OmronPlcRx/Core/Requests/ReadCycleTimeRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadCycleTimeRequest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class ReadCycleTimeRequest : FINSRequest
+{
+    private ReadCycleTimeRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal static ReadCycleTimeRequest CreateNew(OmronPLC plc) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.Status,
+        SubFunctionCode = (byte)StatusFunctionCode.ReadCycleTime,
+    };
+
+    protected override List<byte> BuildRequestData()
+    {
+        var data = new List<byte>();
+
+        // Read Cycle Time
+        data.Add(01);
+
+        return data;
+    }
+}

--- a/src/OmronPlcRx/Core/Requests/ReadMemoryAreaBitRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadMemoryAreaBitRequest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+using OmronPlcRx.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class ReadMemoryAreaBitRequest : FINSRequest
+{
+    private ReadMemoryAreaBitRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal ushort Address { get; set; }
+
+    internal byte StartBitIndex { get; set; }
+
+    internal ushort Length { get; set; }
+
+    internal MemoryBitDataType DataType { get; set; }
+
+    internal static ReadMemoryAreaBitRequest CreateNew(OmronPLC plc, ushort address, byte startBitIndex, ushort length, MemoryBitDataType dataType) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.MemoryArea,
+        SubFunctionCode = (byte)MemoryAreaFunctionCode.Read,
+        Address = address,
+        StartBitIndex = startBitIndex,
+        Length = length,
+        DataType = dataType,
+    };
+
+    protected override List<byte> BuildRequestData()
+    {
+        var data = new List<byte>(1 + 2 + 1 + 2)
+        {
+            // Memory Area Data Type
+            (byte)DataType
+        };
+
+        // Address (big-endian)
+        var addr = BitConverter.GetBytes(Address);
+        Array.Reverse(addr);
+        data.AddRange(addr);
+
+        // Bit Index
+        data.Add(StartBitIndex);
+
+        // Length (big-endian)
+        var len = BitConverter.GetBytes(Length);
+        Array.Reverse(len);
+        data.AddRange(len);
+
+        return data;
+    }
+}

--- a/src/OmronPlcRx/Core/Requests/ReadMemoryAreaWordRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadMemoryAreaWordRequest.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+using OmronPlcRx.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class ReadMemoryAreaWordRequest : FINSRequest
+{
+    private ReadMemoryAreaWordRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal ushort StartAddress { get; set; }
+
+    internal ushort Length { get; set; }
+
+    internal MemoryWordDataType DataType { get; set; }
+
+    internal static ReadMemoryAreaWordRequest CreateNew(OmronPLC plc, ushort startAddress, ushort length, MemoryWordDataType dataType) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.MemoryArea,
+        SubFunctionCode = (byte)MemoryAreaFunctionCode.Read,
+        StartAddress = startAddress,
+        Length = length,
+        DataType = dataType,
+    };
+
+    protected override List<byte> BuildRequestData()
+    {
+        var data = new List<byte>
+        {
+            // Memory Area Data Type
+            (byte)DataType
+        };
+
+        // Address (big-endian)
+        var addr = BitConverter.GetBytes(StartAddress);
+        Array.Reverse(addr);
+        data.AddRange(addr);
+
+        // Reserved
+        data.Add(0);
+
+        // Length (big-endian)
+        var len = BitConverter.GetBytes(Length);
+        Array.Reverse(len);
+        data.AddRange(len);
+
+        return data;
+    }
+}

--- a/src/OmronPlcRx/Core/Requests/WriteClockRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/WriteClockRequest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class WriteClockRequest : FINSRequest
+{
+    private WriteClockRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal DateTime DateTime { get; set; }
+
+    internal byte DayOfWeek { get; set; }
+
+    internal static WriteClockRequest CreateNew(OmronPLC plc, DateTime dateTime, byte dayOfWeek) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.TimeData,
+        SubFunctionCode = (byte)TimeDataFunctionCode.WriteClock,
+        DateTime = dateTime,
+        DayOfWeek = dayOfWeek,
+    };
+
+    protected override List<byte> BuildRequestData() => new List<byte>
+        {
+            // Year (Last 2 Digits)
+            BCDConverter.GetBCDByte((byte)(DateTime.Year % 100)),
+
+            // Month
+            BCDConverter.GetBCDByte((byte)DateTime.Month),
+
+            // Day
+            BCDConverter.GetBCDByte((byte)DateTime.Day),
+
+            // Hour
+            BCDConverter.GetBCDByte((byte)DateTime.Hour),
+
+            // Minute
+            BCDConverter.GetBCDByte((byte)DateTime.Minute),
+
+            // Second
+            BCDConverter.GetBCDByte((byte)DateTime.Second),
+
+            // Day of Week
+            BCDConverter.GetBCDByte(DayOfWeek)
+        };
+}

--- a/src/OmronPlcRx/Core/Requests/WriteMemoryAreaBitRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/WriteMemoryAreaBitRequest.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+using OmronPlcRx.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class WriteMemoryAreaBitRequest : FINSRequest
+{
+    private WriteMemoryAreaBitRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal ushort Address { get; set; }
+
+    internal byte StartBitIndex { get; set; }
+
+    internal MemoryBitDataType DataType { get; set; }
+
+    internal bool[]? Values { get; set; }
+
+    internal static WriteMemoryAreaBitRequest CreateNew(OmronPLC plc, ushort address, byte startBitIndex, MemoryBitDataType dataType, bool[] values) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.MemoryArea,
+        SubFunctionCode = (byte)MemoryAreaFunctionCode.Write,
+        Address = address,
+        StartBitIndex = startBitIndex,
+        DataType = dataType,
+        Values = values,
+    };
+
+    protected override List<byte> BuildRequestData()
+    {
+        var data = new List<byte>
+        {
+            // Memory Area Data Type
+            (byte)DataType
+        };
+
+        // Address (big-endian)
+        var addr = BitConverter.GetBytes(Address);
+        Array.Reverse(addr);
+        data.AddRange(addr);
+
+        // Bit Index
+        data.Add(StartBitIndex);
+
+        // Length (big-endian)
+        var len = BitConverter.GetBytes((ushort)Values!.Length);
+        Array.Reverse(len);
+        data.AddRange(len);
+
+        // Bit Values
+        for (var i = 0; i < Values.Length; i++)
+        {
+            data.Add(Values[i] ? (byte)1 : (byte)0);
+        }
+
+        return data;
+    }
+}

--- a/src/OmronPlcRx/Core/Requests/WriteMemoryAreaWordRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/WriteMemoryAreaWordRequest.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Enums;
+using OmronPlcRx.Enums;
+
+namespace OmronPlcRx.Core.Requests;
+
+internal sealed class WriteMemoryAreaWordRequest : FINSRequest
+{
+    private WriteMemoryAreaWordRequest(OmronPLC plc)
+        : base(plc)
+    {
+    }
+
+    internal ushort StartAddress { get; set; }
+
+    internal MemoryWordDataType DataType { get; set; }
+
+    internal short[]? Values { get; set; }
+
+    internal static WriteMemoryAreaWordRequest CreateNew(OmronPLC plc, ushort startAddress, MemoryWordDataType dataType, short[] values) => new(plc)
+    {
+        FunctionCode = (byte)Enums.FunctionCode.MemoryArea,
+        SubFunctionCode = (byte)MemoryAreaFunctionCode.Write,
+        StartAddress = startAddress,
+        DataType = dataType,
+        Values = values,
+    };
+
+    protected override List<byte> BuildRequestData()
+    {
+        var data = new List<byte>
+        {
+            // Memory Area Data Type
+            (byte)DataType
+        };
+
+        // Address (big-endian)
+        var addr = BitConverter.GetBytes(StartAddress);
+        Array.Reverse(addr);
+        data.AddRange(addr);
+
+        // Reserved
+        data.Add(0);
+
+        // Length (big-endian)
+        var len = BitConverter.GetBytes((ushort)Values!.Length);
+        Array.Reverse(len);
+        data.AddRange(len);
+
+        // Word Values (big-endian)
+        foreach (var value in Values)
+        {
+            var bytes = BitConverter.GetBytes(value);
+            Array.Reverse(bytes);
+            data.AddRange(bytes);
+        }
+
+        return data;
+    }
+}


### PR DESCRIPTION
Introduces core request classes for FINS protocol operations, including reading and writing memory areas (bit and word), reading CPU unit data, clock, cycle time, and writing clock. These classes encapsulate message building logic and provide static factory methods for instantiation, supporting both TCP and non-TCP channels.