### PR TITLE
Add result record structs for PLC operations

### DIFF
--- a/src/OmronPlcRx/ReadBitsResult.cs
+++ b/src/OmronPlcRx/ReadBitsResult.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Read Bits operation.
+/// </summary>
+public readonly record struct ReadBitsResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+
+    /// <summary>Gets the bit values read.</summary>
+    public bool[] Values { get; init; }
+}

--- a/src/OmronPlcRx/ReadClockResult.cs
+++ b/src/OmronPlcRx/ReadClockResult.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Read Clock operation.
+/// </summary>
+public readonly record struct ReadClockResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+
+    /// <summary>Gets the PLC clock date/time.</summary>
+    public DateTime Clock { get; init; }
+
+    /// <summary>Gets the day of week reported by the PLC. 0 = Sunday.</summary>
+    public int DayOfWeek { get; init; }
+}

--- a/src/OmronPlcRx/ReadCycleTimeResult.cs
+++ b/src/OmronPlcRx/ReadCycleTimeResult.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Read Cycle Time operation.
+/// </summary>
+public readonly record struct ReadCycleTimeResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+
+    /// <summary>Gets the minimum cycle time in milliseconds.</summary>
+    public double MinimumCycleTime { get; init; }
+
+    /// <summary>Gets the maximum cycle time in milliseconds.</summary>
+    public double MaximumCycleTime { get; init; }
+
+    /// <summary>Gets the average cycle time in milliseconds.</summary>
+    public double AverageCycleTime { get; init; }
+}

--- a/src/OmronPlcRx/ReadWordsResult.cs
+++ b/src/OmronPlcRx/ReadWordsResult.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Read Words operation.
+/// </summary>
+public readonly record struct ReadWordsResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+
+    /// <summary>Gets the word values read.</summary>
+    public short[] Values { get; init; }
+}

--- a/src/OmronPlcRx/WriteBitsResult.cs
+++ b/src/OmronPlcRx/WriteBitsResult.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Write Bits operation.
+/// </summary>
+public readonly record struct WriteBitsResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+}

--- a/src/OmronPlcRx/WriteClockResult.cs
+++ b/src/OmronPlcRx/WriteClockResult.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Write Clock operation.
+/// </summary>
+public readonly record struct WriteClockResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+}

--- a/src/OmronPlcRx/WriteWordsResult.cs
+++ b/src/OmronPlcRx/WriteWordsResult.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Result of a Write Words operation.
+/// </summary>
+public readonly record struct WriteWordsResult
+{
+    /// <summary>Gets the total bytes sent.</summary>
+    public int BytesSent { get; init; }
+
+    /// <summary>Gets the total packets sent.</summary>
+    public int PacketsSent { get; init; }
+
+    /// <summary>Gets the total bytes received.</summary>
+    public int BytesReceived { get; init; }
+
+    /// <summary>Gets the total packets received.</summary>
+    public int PacketsReceived { get; init; }
+
+    /// <summary>Gets the duration in milliseconds.</summary>
+    public double Duration { get; init; }
+}


### PR DESCRIPTION
Introduces readonly record structs for ReadBitsResult, ReadWordsResult, ReadClockResult, ReadCycleTimeResult, WriteBitsResult, WriteWordsResult, and WriteClockResult. These types encapsulate the results and metrics of respective PLC read/write operations, improving code clarity and type safety.