### PR TITLE
Add OmronPLCConnection and FINS response handlers

### DIFF
--- a/src/OmronPlcRx/Core/OmronPLCConnection.cs
+++ b/src/OmronPlcRx/Core/OmronPLCConnection.cs
@@ -1,0 +1,781 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OmronPlcRx.Core.Channels;
+using OmronPlcRx.Core.Requests;
+using OmronPlcRx.Core.Responses;
+using OmronPlcRx.Enums;
+using OmronPlcRx.Results;
+
+namespace OmronPlcRx.Core;
+
+/// <summary>
+/// High-level Omron PLC client facilitating initialization and FINS read/write operations over TCP/UDP.
+/// </summary>
+internal class OmronPLCConnection : IDisposable
+{
+    private readonly object _isInitializedLock = new();
+    private bool _isInitialized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OmronPLCConnection"/> class.
+    /// </summary>
+    /// <param name="localNodeId">Local FINS node identifier (1-254).</param>
+    /// <param name="remoteNodeId">Remote PLC FINS node identifier (1-254, not equal to local).</param>
+    /// <param name="connectionMethod">Transport to use (TCP/UDP).</param>
+    /// <param name="remoteHost">PLC hostname or IP address.</param>
+    /// <param name="port">PLC service port.</param>
+    /// <param name="timeout">Timeout in milliseconds for requests.</param>
+    /// <param name="retries">Number of retries for transient failures.</param>
+    public OmronPLCConnection(byte localNodeId, byte remoteNodeId, ConnectionMethod connectionMethod, string remoteHost, int port = 9600, int timeout = 2000, int retries = 1)
+    {
+        if (localNodeId == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(localNodeId), "The Local Node ID cannot be set to 0");
+        }
+
+        if (localNodeId == 255)
+        {
+            throw new ArgumentOutOfRangeException(nameof(localNodeId), "The Local Node ID cannot be set to 255");
+        }
+
+        LocalNodeID = localNodeId;
+
+        if (remoteNodeId == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(remoteNodeId), "The Remote Node ID cannot be set to 0");
+        }
+
+        if (remoteNodeId == 255)
+        {
+            throw new ArgumentOutOfRangeException(nameof(remoteNodeId), "The Remote Node ID cannot be set to 255");
+        }
+
+        if (remoteNodeId == localNodeId)
+        {
+            throw new ArgumentException("The Remote Node ID cannot be the same as the Local Node ID", nameof(remoteNodeId));
+        }
+
+        RemoteNodeID = remoteNodeId;
+
+        ConnectionMethod = connectionMethod;
+
+        if (remoteHost == null)
+        {
+            throw new ArgumentNullException(nameof(remoteHost), "The Remote Host cannot be Null");
+        }
+
+        if (remoteHost.Length == 0)
+        {
+            throw new ArgumentException("The Remote Host cannot be Empty", nameof(remoteHost));
+        }
+
+        RemoteHost = remoteHost;
+
+        if (port <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(port), "The Port cannot be less than 1");
+        }
+
+        Port = port;
+
+        if (timeout <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "The Timeout Value cannot be less than 1");
+        }
+
+        Timeout = timeout;
+
+        if (retries < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(retries), "The Retries Value cannot be Negative");
+        }
+
+        Retries = retries;
+
+        Channel = ConnectionMethod == ConnectionMethod.UDP ? new UDPChannel(RemoteHost, Port) : new TCPChannel(RemoteHost, Port);
+    }
+
+    /// <summary>
+    /// Gets the local FINS node ID used by the client.
+    /// </summary>
+    public byte LocalNodeID { get; }
+
+    /// <summary>
+    /// Gets the remote FINS node ID of the PLC.
+    /// </summary>
+    public byte RemoteNodeID { get; }
+
+    /// <summary>
+    /// Gets the transport connection method (TCP/UDP).
+    /// </summary>
+    public ConnectionMethod ConnectionMethod { get; }
+
+    /// <summary>
+    /// Gets the PLC hostname or IP address.
+    /// </summary>
+    public string RemoteHost { get; }
+
+    /// <summary>
+    /// Gets the PLC service port.
+    /// </summary>
+    public int Port { get; } = 9600;
+
+    /// <summary>
+    /// Gets or sets the request timeout in milliseconds.
+    /// </summary>
+    public int Timeout { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of retries for transient failures.
+    /// </summary>
+    public int Retries { get; set; }
+
+    /// <summary>
+    /// Gets the detected PLC type.
+    /// </summary>
+    public PLCType PLCType { get; private set; } = PLCType.Unknown;
+
+    /// <summary>
+    /// Gets a value indicating whether the PLC client is initialized.
+    /// </summary>
+    public bool IsInitialized
+    {
+        get
+        {
+            lock (_isInitializedLock)
+            {
+                return _isInitialized;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the PLC controller model string.
+    /// </summary>
+    public string? ControllerModel { get; private set; }
+
+    /// <summary>
+    /// Gets the PLC controller version string.
+    /// </summary>
+    public string? ControllerVersion { get; private set; }
+
+    /// <summary>
+    /// Gets the maximum number of words that can be read in a single request for the detected PLC type.
+    /// </summary>
+    public ushort MaximumReadWordLength => PLCType == PLCType.CP1 ? (ushort)499 : (ushort)999;
+
+    /// <summary>
+    /// Gets the maximum number of words that can be written in a single request for the detected PLC type.
+    /// </summary>
+    public ushort MaximumWriteWordLength => PLCType == PLCType.CP1 ? (ushort)496 : (ushort)996;
+
+    internal BaseChannel Channel { get; }
+
+    internal bool IsNSeries => PLCType switch
+    {
+        PLCType.NJ101 => true,
+        PLCType.NJ301 => true,
+        PLCType.NJ501 => true,
+        PLCType.NX1P2 => true,
+        PLCType.NX102 => true,
+        PLCType.NX701 => true,
+        PLCType.NY512 => true,
+        PLCType.NY532 => true,
+        PLCType.NJ_NX_NY_Series => true,
+        _ => false,
+    };
+
+    internal bool IsCSeries => PLCType switch
+    {
+        PLCType.CP1 => true,
+        PLCType.CJ2 => true,
+        PLCType.C_Series => true,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Initializes the communication channel and queries controller information.
+    /// </summary>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        lock (_isInitializedLock)
+        {
+            if (_isInitialized)
+            {
+                return;
+            }
+        }
+
+        // Initialize the Channel
+        try
+        {
+            await Channel.InitializeAsync(Timeout, cancellationToken);
+        }
+        catch (ObjectDisposedException)
+        {
+            throw new OmronPLCException("Failed to Create the Ethernet UDP Communication Channel for Omron PLC '" + RemoteHost + ":" + Port + "' - The underlying Socket Connection has been Closed");
+        }
+        catch (TimeoutException)
+        {
+            throw new OmronPLCException("Failed to Create the Ethernet UDP Communication Channel within the Timeout Period for Omron PLC '" + RemoteHost + ":" + Port + "'");
+        }
+        catch (System.Net.Sockets.SocketException e)
+        {
+            throw new OmronPLCException("Failed to Create the Ethernet UDP Communication Channel for Omron PLC '" + RemoteHost + ":" + Port + "'", e);
+        }
+
+        await RequestControllerInformation(cancellationToken);
+
+        lock (_isInitializedLock)
+        {
+            _isInitialized = true;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Read a single bit value.
+    /// </summary>
+    /// <param name="address">The word address containing the target bit.</param>
+    /// <param name="bitIndex">The bit index within the word (0-15).</param>
+    /// <param name="dataType">The bit memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The read bit result.</returns>
+    public Task<ReadBitsResult> ReadBitAsync(ushort address, byte bitIndex, MemoryBitDataType dataType, CancellationToken cancellationToken) => ReadBitsAsync(address, bitIndex, 1, dataType, cancellationToken);
+
+    /// <summary>
+    /// Read a sequence of bit values.
+    /// </summary>
+    /// <param name="address">The word address containing the first bit.</param>
+    /// <param name="startBitIndex">The starting bit index within the word (0-15).</param>
+    /// <param name="length">Number of bits to read (1-16, not crossing word boundary).</param>
+    /// <param name="dataType">The bit memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The read bits result including values and transmission metrics.</returns>
+    public async Task<ReadBitsResult> ReadBitsAsync(ushort address, byte startBitIndex, byte length, MemoryBitDataType dataType, CancellationToken cancellationToken)
+    {
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        if (startBitIndex > 15)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startBitIndex), "The Start Bit Index cannot be greater than 15");
+        }
+
+        if (length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "The Length cannot be Zero");
+        }
+
+        if (startBitIndex + length > 16)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "The Start Bit Index and Length combined are greater than the Maximum Allowed of 16 Bits");
+        }
+
+        if (!ValidateBitDataType(dataType))
+        {
+            throw new ArgumentException("The Data Type '" + Enum.GetName(typeof(MemoryBitDataType), dataType) + "' is not Supported on this PLC", nameof(dataType));
+        }
+
+        if (!ValidateBitAddress(address, dataType))
+        {
+            throw new ArgumentOutOfRangeException(nameof(address), "The Address is greater than the Maximum Address for the '" + Enum.GetName(typeof(MemoryBitDataType), dataType) + "' Data Type");
+        }
+
+        var request = ReadMemoryAreaBitRequest.CreateNew(this, address, startBitIndex, length, dataType);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        return new ReadBitsResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+            Values = ReadMemoryAreaBitResponse.ExtractValues(request, requestResult.Response),
+        };
+    }
+
+    /// <summary>
+    /// Read a single word value.
+    /// </summary>
+    /// <param name="address">The starting address to read.</param>
+    /// <param name="dataType">The word memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The read words result including values and transmission metrics.</returns>
+    public Task<ReadWordsResult> ReadWordAsync(ushort address, MemoryWordDataType dataType, CancellationToken cancellationToken) => ReadWordsAsync(address, 1, dataType, cancellationToken);
+
+    /// <summary>
+    /// Read a sequence of word values.
+    /// </summary>
+    /// <param name="startAddress">The starting address to read.</param>
+    /// <param name="length">Number of words to read.</param>
+    /// <param name="dataType">The word memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The read words result including values and transmission metrics.</returns>
+    public async Task<ReadWordsResult> ReadWordsAsync(ushort startAddress, ushort length, MemoryWordDataType dataType, CancellationToken cancellationToken)
+    {
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        if (length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "The Length cannot be Zero");
+        }
+
+        if (length > MaximumReadWordLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "The Length cannot be greater than " + MaximumReadWordLength.ToString());
+        }
+
+        if (!ValidateWordDataType(dataType))
+        {
+            throw new ArgumentException("The Data Type '" + Enum.GetName(typeof(MemoryWordDataType), dataType) + "' is not Supported on this PLC", nameof(dataType));
+        }
+
+        if (!ValidateWordStartAddress(startAddress, length, dataType))
+        {
+            throw new ArgumentOutOfRangeException(nameof(startAddress), "The Start Address and Length combined are greater than the Maximum Address for the '" + Enum.GetName(typeof(MemoryWordDataType), dataType) + "' Data Type");
+        }
+
+        var request = ReadMemoryAreaWordRequest.CreateNew(this, startAddress, length, dataType);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        return new ReadWordsResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+            Values = ReadMemoryAreaWordResponse.ExtractValues(request, requestResult.Response),
+        };
+    }
+
+    /// <summary>
+    /// Write a single bit value.
+    /// </summary>
+    /// <param name="value">The bit value to write.</param>
+    /// <param name="address">The word address containing the target bit.</param>
+    /// <param name="bitIndex">The bit index within the word (0-15).</param>
+    /// <param name="dataType">The bit memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The write bits result containing transmission metrics.</returns>
+    public Task<WriteBitsResult> WriteBitAsync(bool value, ushort address, byte bitIndex, MemoryBitDataType dataType, CancellationToken cancellationToken) => WriteBitsAsync(new bool[] { value }, address, bitIndex, dataType, cancellationToken);
+
+    /// <summary>
+    /// Write a sequence of bit values.
+    /// </summary>
+    /// <param name="values">The bit values to write.</param>
+    /// <param name="address">The word address containing the first bit.</param>
+    /// <param name="startBitIndex">The starting bit index within the word (0-15).</param>
+    /// <param name="dataType">The bit memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The write bits result containing transmission metrics.</returns>
+    public async Task<WriteBitsResult> WriteBitsAsync(bool[] values, ushort address, byte startBitIndex, MemoryBitDataType dataType, CancellationToken cancellationToken)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        if (startBitIndex > 15)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startBitIndex), "The Start Bit Index cannot be greater than 15");
+        }
+
+        if (values.Length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(values), "The Values Array cannot be Empty");
+        }
+
+        if (startBitIndex + values.Length > 16)
+        {
+            throw new ArgumentOutOfRangeException(nameof(values), "The Values Array Length was greater than the Maximum Allowed of 16 Bits");
+        }
+
+        if (!ValidateBitDataType(dataType))
+        {
+            throw new ArgumentException("The Data Type '" + Enum.GetName(typeof(MemoryBitDataType), dataType) + "' is not Supported on this PLC", nameof(dataType));
+        }
+
+        if (!ValidateBitAddress(address, dataType))
+        {
+            throw new ArgumentOutOfRangeException(nameof(address), "The Address is greater than the Maximum Address for the '" + Enum.GetName(typeof(MemoryBitDataType), dataType) + "' Data Type");
+        }
+
+        var request = WriteMemoryAreaBitRequest.CreateNew(this, address, startBitIndex, dataType, values);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        WriteMemoryAreaBitResponse.Validate(request, requestResult.Response);
+
+        return new WriteBitsResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+        };
+    }
+
+    /// <summary>
+    /// Write a single word value.
+    /// </summary>
+    /// <param name="value">The word value to write.</param>
+    /// <param name="address">The starting address to write.</param>
+    /// <param name="dataType">The word memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The write words result containing transmission metrics.</returns>
+    public Task<WriteWordsResult> WriteWordAsync(short value, ushort address, MemoryWordDataType dataType, CancellationToken cancellationToken) => WriteWordsAsync(new short[] { value }, address, dataType, cancellationToken);
+
+    /// <summary>
+    /// Write a sequence of word values.
+    /// </summary>
+    /// <param name="values">The word values to write.</param>
+    /// <param name="startAddress">The starting address to write.</param>
+    /// <param name="dataType">The word memory area.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The write words result containing transmission metrics.</returns>
+    public async Task<WriteWordsResult> WriteWordsAsync(short[] values, ushort startAddress, MemoryWordDataType dataType, CancellationToken cancellationToken)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        if (values.Length == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(values), "The Values Array cannot be Empty");
+        }
+
+        if (values.Length > MaximumWriteWordLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(values), "The Values Array Length cannot be greater than " + MaximumWriteWordLength.ToString());
+        }
+
+        if (!ValidateWordDataType(dataType))
+        {
+            throw new ArgumentException("The Data Type '" + Enum.GetName(typeof(MemoryWordDataType), dataType) + "' is not Supported on this PLC", nameof(dataType));
+        }
+
+        if (!ValidateWordStartAddress(startAddress, values.Length, dataType))
+        {
+            throw new ArgumentOutOfRangeException(nameof(startAddress), "The Start Address and Values Array Length combined are greater than the Maximum Address for the '" + Enum.GetName(typeof(MemoryWordDataType), dataType) + "' Data Type");
+        }
+
+        var request = WriteMemoryAreaWordRequest.CreateNew(this, startAddress, dataType, values);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        WriteMemoryAreaWordResponse.Validate(request, requestResult.Response);
+
+        return new WriteWordsResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+        };
+    }
+
+    /// <summary>
+    /// Read the current PLC real-time clock value.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The read clock result.</returns>
+    public async Task<ReadClockResult> ReadClockAsync(CancellationToken cancellationToken)
+    {
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        var request = ReadClockRequest.CreateNew(this);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        var result = ReadClockResponse.ExtractClock(request, requestResult.Response);
+
+        return new ReadClockResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+            Clock = result.ClockDateTime,
+            DayOfWeek = result.DayOfWeek
+        };
+    }
+
+    /// <summary>
+    /// Write the PLC real-time clock value.
+    /// </summary>
+    /// <param name="newDateTime">The new date and time.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The write clock result.</returns>
+    public Task<WriteClockResult> WriteClockAsync(DateTime newDateTime, CancellationToken cancellationToken) => WriteClockAsync(newDateTime, (int)newDateTime.DayOfWeek, cancellationToken);
+
+    /// <summary>
+    /// Write the PLC real-time clock value with a specific day-of-week.
+    /// </summary>
+    /// <param name="newDateTime">The new date and time.</param>
+    /// <param name="newDayOfWeek">The day of week (0-6).</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The write clock result.</returns>
+    public async Task<WriteClockResult> WriteClockAsync(DateTime newDateTime, int newDayOfWeek, CancellationToken cancellationToken)
+    {
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        var minDateTime = new DateTime(1998, 1, 1, 0, 0, 0);
+
+        if (newDateTime < minDateTime)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newDateTime), "The Date Time Value cannot be less than '" + minDateTime.ToString() + "'");
+        }
+
+        var maxDateTime = new DateTime(2069, 12, 31, 23, 59, 59);
+
+        if (newDateTime > maxDateTime)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newDateTime), "The Date Time Value cannot be greater than '" + maxDateTime.ToString() + "'");
+        }
+
+        if (newDayOfWeek < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newDayOfWeek), "The Day of Week Value cannot be less than 0");
+        }
+
+        if (newDayOfWeek > 6)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newDayOfWeek), "The Day of Week Value cannot be greater than 6");
+        }
+
+        var request = WriteClockRequest.CreateNew(this, newDateTime, (byte)newDayOfWeek);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        WriteClockResponse.Validate(request, requestResult.Response);
+
+        return new WriteClockResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+        };
+    }
+
+    /// <summary>
+    /// Read the PLC scan cycle time statistics.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The read cycle time result with minimum/maximum/average values.</returns>
+    public async Task<ReadCycleTimeResult> ReadCycleTimeAsync(CancellationToken cancellationToken)
+    {
+        lock (_isInitializedLock)
+        {
+            if (!_isInitialized)
+            {
+                throw new OmronPLCException("This Omron PLC must be Initialized first before any Requests can be Processed");
+            }
+        }
+
+        if (IsNSeries && PLCType != PLCType.NJ101 && PLCType != PLCType.NJ301 && PLCType != PLCType.NJ501)
+        {
+            throw new OmronPLCException("Read Cycle Time is not Supported on the NX/NY Series PLC");
+        }
+
+        var request = ReadCycleTimeRequest.CreateNew(this);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        var result = ReadCycleTimeResponse.ExtractCycleTime(request, requestResult.Response);
+
+        return new ReadCycleTimeResult
+        {
+            BytesSent = requestResult.BytesSent,
+            PacketsSent = requestResult.PacketsSent,
+            BytesReceived = requestResult.BytesReceived,
+            PacketsReceived = requestResult.PacketsReceived,
+            Duration = requestResult.Duration,
+            MinimumCycleTime = result.MinimumCycleTime,
+            MaximumCycleTime = result.MaximumCycleTime,
+            AverageCycleTime = result.AverageCycleTime,
+        };
+    }
+
+    /// <summary>
+    /// Releases resources used by the client and channel.
+    /// </summary>
+    /// <param name="disposing">True to dispose managed resources; otherwise, false.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Channel.Dispose();
+
+            lock (_isInitializedLock)
+            {
+                _isInitialized = false;
+            }
+        }
+    }
+
+    private bool ValidateBitAddress(ushort address, MemoryBitDataType dataType) => dataType switch
+    {
+        MemoryBitDataType.DataMemory => address < (PLCType == PLCType.NX1P2 ? 16000 : 32768),
+        MemoryBitDataType.CommonIO => address < 6144,
+        MemoryBitDataType.Work => address < 512,
+        MemoryBitDataType.Holding => address < 1536,
+        MemoryBitDataType.Auxiliary => address < (PLCType == PLCType.CJ2 ? 11536 : 960),
+        _ => false,
+    };
+
+    private bool ValidateBitDataType(MemoryBitDataType dataType) => dataType switch
+    {
+        MemoryBitDataType.DataMemory => PLCType != PLCType.CP1,
+        MemoryBitDataType.CommonIO => true,
+        MemoryBitDataType.Work => true,
+        MemoryBitDataType.Holding => true,
+        MemoryBitDataType.Auxiliary => !IsNSeries,
+        _ => false,
+    };
+
+    private bool ValidateWordStartAddress(ushort startAddress, int length, MemoryWordDataType dataType) => dataType switch
+    {
+        MemoryWordDataType.DataMemory => startAddress + (length - 1) < (PLCType == PLCType.NX1P2 ? 16000 : 32768),
+        MemoryWordDataType.CommonIO => startAddress + (length - 1) < 6144,
+        MemoryWordDataType.Work => startAddress + (length - 1) < 512,
+        MemoryWordDataType.Holding => startAddress + (length - 1) < 1536,
+        MemoryWordDataType.Auxiliary => startAddress + (length - 1) < (PLCType == PLCType.CJ2 ? 11536 : 960),
+        _ => false,
+    };
+
+    private bool ValidateWordDataType(MemoryWordDataType dataType) => dataType switch
+    {
+        MemoryWordDataType.DataMemory => true,
+        MemoryWordDataType.CommonIO => true,
+        MemoryWordDataType.Work => true,
+        MemoryWordDataType.Holding => true,
+        MemoryWordDataType.Auxiliary => !IsNSeries,
+        _ => false,
+    };
+
+    private async Task RequestControllerInformation(CancellationToken cancellationToken)
+    {
+        var request = ReadCPUUnitDataRequest.CreateNew(this);
+
+        var requestResult = await Channel.ProcessRequestAsync(request, Timeout, Retries, cancellationToken);
+
+        var result = ReadCPUUnitDataResponse.ExtractData(requestResult.Response);
+
+        if (result.ControllerModel?.Length > 0)
+        {
+            ControllerModel = result.ControllerModel;
+
+            if (ControllerModel.StartsWith("NJ101"))
+            {
+                PLCType = PLCType.NJ101;
+            }
+            else if (ControllerModel.StartsWith("NJ301"))
+            {
+                PLCType = PLCType.NJ301;
+            }
+            else if (ControllerModel.StartsWith("NJ501"))
+            {
+                PLCType = PLCType.NJ501;
+            }
+            else if (ControllerModel.StartsWith("NX1P2"))
+            {
+                PLCType = PLCType.NX1P2;
+            }
+            else if (ControllerModel.StartsWith("NX102"))
+            {
+                PLCType = PLCType.NX102;
+            }
+            else if (ControllerModel.StartsWith("NX701"))
+            {
+                PLCType = PLCType.NX701;
+            }
+            else if (ControllerModel.StartsWith("NJ") || ControllerModel.StartsWith("NX") || ControllerModel.StartsWith("NY"))
+            {
+                PLCType = PLCType.NJ_NX_NY_Series;
+            }
+            else if (ControllerModel.StartsWith("CJ2"))
+            {
+                PLCType = PLCType.CJ2;
+            }
+            else if (ControllerModel.StartsWith("CP1"))
+            {
+                PLCType = PLCType.CP1;
+            }
+            else if (ControllerModel.StartsWith("C"))
+            {
+                PLCType = PLCType.C_Series;
+            }
+            else
+            {
+                PLCType = PLCType.Unknown;
+            }
+        }
+
+        if (result.ControllerVersion?.Length > 0)
+        {
+            ControllerVersion = result.ControllerVersion;
+        }
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/ReadCPUUnitDataResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadCPUUnitDataResponse.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class ReadCPUUnitDataResponse
+{
+    internal const int ControllerModelLength = 20;
+    internal const int ControllerVersionLength = 20;
+    internal const int SystemReservedLength = 40;
+    internal const int AreaDataLength = 12;
+
+    internal static CPUUnitDataResult ExtractData(FINSResponse response)
+    {
+        var expectedLength = ControllerModelLength + ControllerVersionLength + SystemReservedLength + AreaDataLength;
+
+        if (response.Data?.Length < expectedLength)
+        {
+            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + expectedLength.ToString() + "'");
+        }
+
+        var data = response.Data;
+
+        var result = default(CPUUnitDataResult);
+
+        result.ControllerModel = ExtractStringValue(SubArray(data, 0, ControllerModelLength));
+
+        result.ControllerVersion = ExtractStringValue(SubArray(data, ControllerModelLength, ControllerVersionLength));
+
+        return result;
+    }
+
+    private static string ExtractStringValue(byte[] bytes)
+    {
+        var stringBytes = new List<byte>(bytes.Length);
+
+        foreach (var byteValue in bytes)
+        {
+            if (byteValue > 0)
+            {
+                stringBytes.Add(byteValue);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (stringBytes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return ASCIIEncoding.ASCII.GetString([.. stringBytes]).Trim();
+    }
+
+    private static byte[] SubArray(byte[]? data, int index, int length)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        var result = new byte[length];
+        Array.Copy(data, index, result, 0, length);
+        return result;
+    }
+
+    internal struct CPUUnitDataResult
+    {
+        internal string ControllerModel;
+        internal string ControllerVersion;
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/ReadClockResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadClockResponse.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using OmronPlcRx.Core.Converters;
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class ReadClockResponse
+{
+    internal const int DateLength = 6;
+    internal const int DayOfWeekLength = 1;
+
+    internal static ClockResult ExtractClock(ReadClockRequest request, FINSResponse response)
+    {
+        if (response.Data?.Length < DateLength + DayOfWeekLength)
+        {
+            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + (DateLength + DayOfWeekLength).ToString() + "'");
+        }
+
+        var data = response.Data;
+
+        return new ClockResult
+        {
+            ClockDateTime = GetClockDateTime(SubArray(data, 0, DateLength)),
+            DayOfWeek = BCDConverter.ToByte(data![DateLength]),
+        };
+    }
+
+    private static DateTime GetClockDateTime(byte[] bytes)
+    {
+        var year = BCDConverter.ToByte(bytes[0]);
+        var month = BCDConverter.ToByte(bytes[1]);
+        var day = BCDConverter.ToByte(bytes[2]);
+        var hour = BCDConverter.ToByte(bytes[3]);
+        var minute = BCDConverter.ToByte(bytes[4]);
+        var second = BCDConverter.ToByte(bytes[5]);
+
+        if (year < 70)
+        {
+            return new DateTime(2000 + year, month, day, hour, minute, second);
+        }
+        else if (year < 100)
+        {
+            return new DateTime(1900 + year, month, day, hour, minute, second);
+        }
+
+        throw new FINSException("Invalid DateTime Values received from the PLC Clock");
+    }
+
+    private static byte[] SubArray(byte[]? data, int index, int length)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        var result = new byte[length];
+        Array.Copy(data, index, result, 0, length);
+        return result;
+    }
+
+    internal struct ClockResult
+    {
+        internal DateTime ClockDateTime;
+        internal byte DayOfWeek;
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/ReadCycleTimeResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadCycleTimeResponse.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using OmronPlcRx.Core.Converters;
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class ReadCycleTimeResponse
+{
+    internal const int CycleTimeItemLength = 4;
+
+    internal static CycleTimeResult ExtractCycleTime(ReadCycleTimeRequest request, FINSResponse response)
+    {
+        if (response.Data?.Length < CycleTimeItemLength * 3)
+        {
+            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + (CycleTimeItemLength * 3).ToString() + "'");
+        }
+
+        var data = response.Data;
+
+        return new CycleTimeResult
+        {
+            AverageCycleTime = GetCycleTime(SubArray(data, 0, CycleTimeItemLength)),
+            MaximumCycleTime = GetCycleTime(SubArray(data, CycleTimeItemLength, CycleTimeItemLength)),
+            MinimumCycleTime = GetCycleTime(SubArray(data, CycleTimeItemLength * 2, CycleTimeItemLength)),
+        };
+    }
+
+    private static double GetCycleTime(byte[] bytes)
+    {
+        if (bytes.Length != 4)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bytes), "The Cycle Time Bytes Array Length must be 4");
+        }
+
+        Array.Reverse(bytes);
+        var cycleTimeValue = BCDConverter.ToUInt32(bytes);
+
+        if (cycleTimeValue > 0)
+        {
+            return cycleTimeValue / 10d;
+        }
+
+        return 0;
+    }
+
+    private static byte[] SubArray(byte[]? data, int index, int length)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data), "The Data Array cannot be null");
+        }
+
+        var result = new byte[length];
+        Array.Copy(data, index, result, 0, length);
+        return result;
+    }
+
+    internal struct CycleTimeResult
+    {
+        internal double MinimumCycleTime;
+        internal double MaximumCycleTime;
+        internal double AverageCycleTime;
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/ReadMemoryAreaBitResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadMemoryAreaBitResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class ReadMemoryAreaBitResponse
+{
+    internal static bool[] ExtractValues(ReadMemoryAreaBitRequest request, FINSResponse response)
+    {
+        if (response.Data?.Length < request.Length)
+        {
+            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + request.Length.ToString() + "'");
+        }
+
+        var result = new bool[request.Length];
+        var data = response.Data;
+        for (var i = 0; i < request.Length; i++)
+        {
+            result[i] = data![i] != 0;
+        }
+
+        return result;
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/ReadMemoryAreaWordResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadMemoryAreaWordResponse.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class ReadMemoryAreaWordResponse
+{
+    internal static short[] ExtractValues(ReadMemoryAreaWordRequest request, FINSResponse response)
+    {
+        if (response.Data?.Length < request.Length * 2)
+        {
+            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + (request.Length * 2).ToString() + "'");
+        }
+
+        var values = new short[request.Length];
+        var data = response.Data;
+
+        for (int i = 0, w = 0; i < request.Length * 2; i += 2, w++)
+        {
+            // Data is big-endian per protocol, convert to host order (little-endian)
+            var value = (short)((data![i] << 8) | data[i + 1]);
+            values[w] = value;
+        }
+
+        return values;
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/WriteClockResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/WriteClockResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class WriteClockResponse
+{
+    internal static void Validate(WriteClockRequest request, FINSResponse response)
+    {
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/WriteMemoryAreaBitResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/WriteMemoryAreaBitResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class WriteMemoryAreaBitResponse
+{
+    internal static void Validate(WriteMemoryAreaBitRequest request, FINSResponse response)
+    {
+    }
+}

--- a/src/OmronPlcRx/Core/Responses/WriteMemoryAreaWordResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/WriteMemoryAreaWordResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using OmronPlcRx.Core.Requests;
+
+namespace OmronPlcRx.Core.Responses;
+
+internal static class WriteMemoryAreaWordResponse
+{
+    internal static void Validate(WriteMemoryAreaWordRequest request, FINSResponse response)
+    {
+    }
+}

--- a/src/OmronPlcRx/IOmronPlcRx.cs
+++ b/src/OmronPlcRx/IOmronPlcRx.cs
@@ -17,7 +17,7 @@ namespace OmronPlcRx
         /// <value>
         /// The observe all.
         /// </value>
-        IObservable<string?> ObserveAll { get; }
+        IObservable<object?> ObserveAll { get; }
 
         /// <summary>
         /// Gets the errors.

--- a/src/OmronPlcRx/OmronPlcRx.cs
+++ b/src/OmronPlcRx/OmronPlcRx.cs
@@ -1,0 +1,453 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using OmronPlcRx.Core;
+using OmronPlcRx.Enums;
+using OmronPlcRx.Tags;
+
+namespace OmronPlcRx;
+
+/// <summary>
+/// Reactive wrapper providing typed tag storage, polling and observation for an <see cref="OmronPLCConnection"/> instance.
+/// Implements <see cref="IOmronPlcRx"/> so individual tag streams and a multiplex stream can be consumed.
+/// </summary>
+public sealed class OmronPlcRx : IOmronPlcRx
+{
+    private readonly OmronPLCConnection _plc;
+    private readonly TimeSpan _pollInterval;
+    private readonly ConcurrentDictionary<string, ITagEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, object> _subjects = new(StringComparer.OrdinalIgnoreCase); // value is BehaviorSubject<object?>
+    private readonly Subject<object?> _tagChanged = new();
+    private readonly Subject<OmronPLCException?> _errors = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _pollLoop;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OmronPlcRx" /> class.
+    /// </summary>
+    /// <param name="localNodeId">The local node identifier.</param>
+    /// <param name="remoteNodeId">The remote node identifier.</param>
+    /// <param name="connectionMethod">The connection method.</param>
+    /// <param name="remoteHost">The remote host.</param>
+    /// <param name="port">The port.</param>
+    /// <param name="timeout">The timeout.</param>
+    /// <param name="retries">The retries.</param>
+    /// <param name="pollInterval">Polling interval (default 100 ms).</param>
+    public OmronPlcRx(byte localNodeId, byte remoteNodeId, ConnectionMethod connectionMethod, string remoteHost, int port = 9600, int timeout = 2000, int retries = 1, TimeSpan? pollInterval = null)
+    {
+        _plc = new(localNodeId, remoteNodeId, connectionMethod, remoteHost, port, timeout, retries);
+        _pollInterval = pollInterval ?? TimeSpan.FromMilliseconds(100);
+        _pollLoop = Task.Run(PollLoopAsync);
+    }
+
+    /// <summary>
+    /// ITagEntry.
+    /// </summary>
+    private interface ITagEntry
+    {
+        /// <summary>
+        /// Gets the boxed value.
+        /// </summary>
+        /// <value>
+        /// The boxed value.
+        /// </value>
+        object BoxedValue { get; }
+
+        /// <summary>
+        /// Reads the asynchronous.
+        /// </summary>
+        /// <param name="plc">The PLC.</param>
+        /// <param name="ct">The ct.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<bool> ReadAsync(OmronPLCConnection plc, CancellationToken ct);
+    }
+
+    /// <inheritdoc />
+    public IObservable<object?> ObserveAll => _tagChanged.AsObservable();
+
+    /// <inheritdoc />
+    public IObservable<OmronPLCException?> Errors => _errors.AsObservable();
+
+    /// <inheritdoc />
+    public bool IsDisposed => _disposed;
+
+    /// <inheritdoc />
+    public void AddUpdateTagItem<T>(string variable, string tagName)
+    {
+        if (string.IsNullOrWhiteSpace(variable))
+        {
+            throw new ArgumentNullException(nameof(variable));
+        }
+
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        var tag = new PlcTag<T>(tagName, variable);
+        var entry = new TagEntry<T>(tag);
+        _entries.AddOrUpdate(tagName, entry, (_, __) => entry);
+        _subjects.GetOrAdd(tagName, _ => new BehaviorSubject<object?>(default));
+    }
+
+    /// <inheritdoc />
+    public IObservable<T?> Observe<T>(string? tagName)
+    {
+        if (tagName == null)
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        var subject = (BehaviorSubject<object?>)_subjects.GetOrAdd(tagName, _ => new BehaviorSubject<object?>(default));
+        return subject.Select(v => v is null ? default : (T?)ConvertTo<T>(v));
+    }
+
+    /// <inheritdoc />
+    public T? Value<T>(string? tagName)
+    {
+        if (tagName == null)
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        if (_entries.TryGetValue(tagName, out var entry) && entry is TagEntry<T> typed)
+        {
+            return typed.Tag.Value;
+        }
+
+        return default;
+    }
+
+    /// <inheritdoc />
+    public void Value<T>(string? tagName, T? value)
+    {
+        if (tagName == null)
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        if (!_entries.TryGetValue(tagName, out var entry) || entry is not TagEntry<T> typed)
+        {
+            throw new KeyNotFoundException($"Tag '{tagName}' not found or incorrect type.");
+        }
+
+        // Write to PLC synchronously by scheduling (do not block caller)
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await WriteValueAsync(typed, value, _cts.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _errors.OnNext(new OmronPLCException($"Failed to write tag '{tagName}'", ex));
+            }
+        });
+    }
+
+    /// <summary>
+    /// Dispose pattern.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _cts.Cancel();
+        try
+        {
+            _pollLoop.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+        }
+
+        foreach (var s in _subjects.Values)
+        {
+            if (s is BehaviorSubject<object?> bs)
+            {
+                bs.OnCompleted();
+                bs.Dispose();
+            }
+        }
+
+        _tagChanged.OnCompleted();
+        _errors.OnCompleted();
+        _tagChanged.Dispose();
+        _errors.Dispose();
+        _plc.Dispose();
+        _cts.Dispose();
+    }
+
+    private static object? ConvertTo<T>(object value)
+    {
+        if (value is T t)
+        {
+            return t;
+        }
+
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+
+    private static (string Area, ushort Address, byte? BitIndex) ParseAddress(string address)
+    {
+        var dotIndex = address.IndexOf('.');
+        string basePart;
+        string bitPart = null;
+        if (dotIndex >= 0)
+        {
+            basePart = address.Substring(0, dotIndex);
+            bitPart = address[(dotIndex + 1)..];
+        }
+        else
+        {
+            basePart = address;
+        }
+
+        byte? bitIndex = null;
+        if (bitPart != null)
+        {
+            if (!byte.TryParse(bitPart, out var bi) || bi > 15)
+            {
+                throw new FormatException($"Invalid bit index in address '{address}'");
+            }
+
+            bitIndex = bi;
+        }
+
+        var firstDigit = -1;
+        for (var i = 0; i < basePart.Length; i++)
+        {
+            if (char.IsDigit(basePart[i]))
+            {
+                firstDigit = i;
+                break;
+            }
+        }
+
+        if (firstDigit < 0)
+        {
+            throw new FormatException($"No numeric portion in address '{address}'");
+        }
+
+        var area = basePart[..firstDigit].ToUpperInvariant();
+        var numberPart = basePart[firstDigit..];
+        if (!ushort.TryParse(numberPart, out var addr))
+        {
+            throw new FormatException($"Invalid numeric address in '{address}'");
+        }
+
+        return (area, addr, bitIndex);
+    }
+
+    private static MemoryBitDataType ToBitType(string area) => area switch
+    {
+        "D" or "DM" => MemoryBitDataType.DataMemory,
+        "C" or "CIO" => MemoryBitDataType.CommonIO,
+        "W" => MemoryBitDataType.Work,
+        "H" => MemoryBitDataType.Holding,
+        "A" => MemoryBitDataType.Auxiliary,
+        _ => throw new ArgumentOutOfRangeException(nameof(area), $"Unsupported bit area '{area}'"),
+    };
+
+    private static MemoryWordDataType ToWordType(string area) => area switch
+    {
+        "D" or "DM" => MemoryWordDataType.DataMemory,
+        "C" or "CIO" => MemoryWordDataType.CommonIO,
+        "W" => MemoryWordDataType.Work,
+        "H" => MemoryWordDataType.Holding,
+        "A" => MemoryWordDataType.Auxiliary,
+        _ => throw new ArgumentOutOfRangeException(nameof(area), $"Unsupported word area '{area}'"),
+    };
+
+    private async Task PollLoopAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            try
+            {
+                foreach (var kvp in _entries)
+                {
+                    if (_cts.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    var name = kvp.Key;
+                    var entry = kvp.Value;
+                    try
+                    {
+                        var changed = await entry.ReadAsync(_plc, _cts.Token).ConfigureAwait(false);
+                        if (changed)
+                        {
+                            if (_subjects.TryGetValue(name, out var obj) && obj is BehaviorSubject<object?> subj)
+                            {
+                                subj.OnNext(entry.BoxedValue);
+                            }
+
+                            _tagChanged.OnNext(name);
+                        }
+                    }
+                    catch (OmronPLCException ex)
+                    {
+                        _errors.OnNext(new OmronPLCException(ex.Message, ex));
+                    }
+                    catch (Exception ex)
+                    {
+                        _errors.OnNext(new OmronPLCException($"Unexpected error reading tag '{name}'", ex));
+                    }
+                }
+            }
+            catch (Exception loopEx)
+            {
+                _errors.OnNext(new OmronPLCException("Polling loop failure", loopEx));
+            }
+
+            try
+            {
+                await Task.Delay(_pollInterval, _cts.Token).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task WriteValueAsync<T>(TagEntry<T> entry, T? value, CancellationToken ct)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        var (area, addr, bitIndex) = ParseAddress(entry.Tag.Address);
+
+        if (typeof(T) == typeof(bool))
+        {
+            var b = Convert.ToBoolean(value);
+            if (bitIndex is null)
+            {
+                // treat as word bool (0/1)
+                var wordVal = (short)(b ? 1 : 0);
+                await _plc.WriteWordsAsync(new short[] { wordVal }, addr, ToWordType(area), ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await _plc.WriteBitsAsync(new bool[] { b }, addr, bitIndex.Value, ToBitType(area), ct).ConfigureAwait(false);
+            }
+        }
+        else if (typeof(T) == typeof(short))
+        {
+            var s = Convert.ToInt16(value);
+            await _plc.WriteWordsAsync(new short[] { s }, addr, ToWordType(area), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(int))
+        {
+            var i = Convert.ToInt32(value);
+            var hi = (ushort)((i >> 16) & 0xFFFF);
+            var lo = (ushort)(i & 0xFFFF);
+            short[] words = { unchecked((short)hi), unchecked((short)lo) };
+            await _plc.WriteWordsAsync(words, addr, ToWordType(area), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            var f = Convert.ToSingle(value);
+            var bytes = BitConverter.GetBytes(f);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+
+            var hi = (ushort)((bytes[0] << 8) | bytes[1]);
+            var lo = (ushort)((bytes[2] << 8) | bytes[3]);
+            short[] words = { unchecked((short)hi), unchecked((short)lo) };
+            await _plc.WriteWordsAsync(words, addr, ToWordType(area), ct).ConfigureAwait(false);
+        }
+        else
+        {
+            throw new NotSupportedException($"Write not supported for type '{typeof(T).Name}'");
+        }
+
+        entry.Tag.WriteValue = value;
+    }
+
+    private sealed class TagEntry<T>(PlcTag<T> tag) : ITagEntry
+    {
+        public PlcTag<T> Tag { get; } = tag;
+
+        public object BoxedValue => Tag.Value;
+
+        public async Task<bool> ReadAsync(OmronPLCConnection plc, CancellationToken ct)
+        {
+            var (area, addr, bitIndex) = ParseAddress(Tag.Address);
+            object newVal;
+
+            if (typeof(T) == typeof(bool))
+            {
+                if (bitIndex is null)
+                {
+                    var word = await plc.ReadWordAsync(addr, ToWordType(area), ct).ConfigureAwait(false);
+                    newVal = word.Values[0] != 0;
+                }
+                else
+                {
+                    var bits = await plc.ReadBitsAsync(addr, bitIndex.Value, 1, ToBitType(area), ct).ConfigureAwait(false);
+                    newVal = bits.Values[0];
+                }
+            }
+            else if (typeof(T) == typeof(short))
+            {
+                var words = await plc.ReadWordsAsync(addr, 1, ToWordType(area), ct).ConfigureAwait(false);
+                newVal = words.Values[0];
+            }
+            else if (typeof(T) == typeof(int))
+            {
+                var words = await plc.ReadWordsAsync(addr, 2, ToWordType(area), ct).ConfigureAwait(false);
+                var hi = (ushort)words.Values[0];
+                var lo = (ushort)words.Values[1];
+                var composite = ((uint)hi << 16) | lo;
+                newVal = unchecked((int)composite);
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                var words = await plc.ReadWordsAsync(addr, 2, ToWordType(area), ct).ConfigureAwait(false);
+                var hi = (ushort)words.Values[0];
+                var lo = (ushort)words.Values[1];
+                var bytes = new byte[4]
+                {
+                    (byte)(hi >> 8), (byte)(hi & 0xFF), (byte)(lo >> 8), (byte)(lo & 0xFF)
+                };
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(bytes);
+                }
+
+                newVal = BitConverter.ToSingle(bytes, 0);
+            }
+            else
+            {
+                throw new NotSupportedException($"Tag type '{typeof(T).Name}' not supported.");
+            }
+
+            if (!Equals(newVal, Tag.Value))
+            {
+                Tag.Value = (T)newVal;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/OmronPlcRx/Tags/PlcTag.cs
+++ b/src/OmronPlcRx/Tags/PlcTag.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace OmronPlcRx.Tags
+{
+    /// <summary>
+    /// PlcTag.
+    /// </summary>
+    /// <typeparam name="T">The data type.</typeparam>
+    public class PlcTag<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlcTag{T}"/> class.
+        /// </summary>
+        /// <param name="tagName">The tag Name.</param>
+        /// <param name="address">The address.</param>
+        /// <exception cref="ArgumentNullException">
+        /// name
+        /// or
+        /// address.
+        /// </exception>
+        public PlcTag(string tagName, string address)
+        {
+            TagName = tagName ?? throw new ArgumentNullException(nameof(tagName));
+            Address = address ?? throw new ArgumentNullException(nameof(address));
+        }
+
+        /// <summary>
+        /// Gets the Tag Name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
+        public string TagName { get; }
+
+        /// <summary>
+        /// Gets the address.
+        /// </summary>
+        /// <value>
+        /// The address.
+        /// </value>
+        public string Address { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is bit address.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is bit address; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsBitAddress => Address.Contains(".");
+
+        /// <summary>
+        /// Gets the value read.
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
+        public T Value { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the value to write.
+        /// </summary>
+        /// <value>
+        /// The write value.
+        /// </value>
+        public T WriteValue { get; set; }
+    }
+}


### PR DESCRIPTION
Introduces OmronPLCConnection for high-level Omron PLC communication and adds response handler classes for reading and writing CPU unit data, clock, cycle time, memory area bits, and words. These additions enable initialization, FINS read/write operations, and extraction/validation of PLC response data.