### PR TITLE
Refactor tag handling to use IPlcTag interface

### DIFF
--- a/src/OmronPlcRx/IOmronPlcRx.cs
+++ b/src/OmronPlcRx/IOmronPlcRx.cs
@@ -3,64 +3,64 @@
 
 using System;
 using System.Reactive.Disposables;
+using OmronPlcRx.Tags;
 
-namespace OmronPlcRx
+namespace OmronPlcRx;
+
+/// <summary>
+/// IOmronPlcRx.
+/// </summary>
+public interface IOmronPlcRx : ICancelable
 {
     /// <summary>
-    /// IOmronPlcRx.
+    /// Gets the observe all.
     /// </summary>
-    public interface IOmronPlcRx : ICancelable
-    {
-        /// <summary>
-        /// Gets the observe all.
-        /// </summary>
-        /// <value>
-        /// The observe all.
-        /// </value>
-        IObservable<object?> ObserveAll { get; }
+    /// <value>
+    /// The observe all.
+    /// </value>
+    IObservable<IPlcTag?> ObserveAll { get; }
 
-        /// <summary>
-        /// Gets the errors.
-        /// </summary>
-        /// <value>
-        /// The errors.
-        /// </value>
-        IObservable<OmronPLCException?> Errors { get; }
+    /// <summary>
+    /// Gets the errors.
+    /// </summary>
+    /// <value>
+    /// The errors.
+    /// </value>
+    IObservable<OmronPLCException?> Errors { get; }
 
-        /// <summary>
-        /// Adds the update tag item.
-        /// </summary>
-        /// <typeparam name="T">The type to observe.</typeparam>
-        /// <param name="variable">The PLC variable.</param>
-        /// <param name="tagName">Name of the tag.</param>
-        void AddUpdateTagItem<T>(string variable, string tagName);
+    /// <summary>
+    /// Adds the update tag item.
+    /// </summary>
+    /// <typeparam name="T">The type to observe.</typeparam>
+    /// <param name="variable">The PLC variable.</param>
+    /// <param name="tagName">Name of the tag.</param>
+    void AddUpdateTagItem<T>(string variable, string tagName);
 
-        /// <summary>
-        /// Observes the specified variable.
-        /// </summary>
-        /// <typeparam name="T">The PLC type.</typeparam>
-        /// <param name="tagName">The Tag Name.</param>
-        /// <returns>
-        /// An observable sequence of values of type T.
-        /// </returns>
-        IObservable<T?> Observe<T>(string? tagName);
+    /// <summary>
+    /// Observes the specified variable.
+    /// </summary>
+    /// <typeparam name="T">The PLC type.</typeparam>
+    /// <param name="tagName">The Tag Name.</param>
+    /// <returns>
+    /// An observable sequence of values of type T.
+    /// </returns>
+    IObservable<T?> Observe<T>(string? tagName);
 
-        /// <summary>
-        /// Reads the specified variable.
-        /// </summary>
-        /// <typeparam name="T">The PLC type.</typeparam>
-        /// <param name="tagName">The Tag Name.</param>
-        /// <returns>
-        /// A value of T.
-        /// </returns>
-        T? Value<T>(string? tagName);
+    /// <summary>
+    /// Reads the specified variable.
+    /// </summary>
+    /// <typeparam name="T">The PLC type.</typeparam>
+    /// <param name="tagName">The Tag Name.</param>
+    /// <returns>
+    /// A value of T.
+    /// </returns>
+    T? Value<T>(string? tagName);
 
-        /// <summary>
-        /// Writes the specified variable value.
-        /// </summary>
-        /// <typeparam name="T">The PLC type.</typeparam>
-        /// <param name="tagName">The Tag Name.</param>
-        /// <param name="value">The value.</param>
-        void Value<T>(string? tagName, T? value);
-    }
+    /// <summary>
+    /// Writes the specified variable value.
+    /// </summary>
+    /// <typeparam name="T">The PLC type.</typeparam>
+    /// <param name="tagName">The Tag Name.</param>
+    /// <param name="value">The value.</param>
+    void Value<T>(string? tagName, T? value);
 }

--- a/src/OmronPlcRx/OmronPlcRx.csproj
+++ b/src/OmronPlcRx/OmronPlcRx.csproj
@@ -7,12 +7,15 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Memory" Version="4.6.3" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="System.Reactive" Version="6.0.2" />
   </ItemGroup>
 

--- a/src/OmronPlcRx/Tags/IPlcTag.cs
+++ b/src/OmronPlcRx/Tags/IPlcTag.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace OmronPlcRx.Tags
+{
+    /// <summary>
+    /// IPlcTag.
+    /// </summary>
+    public interface IPlcTag
+    {
+        /// <summary>
+        /// Gets the address.
+        /// </summary>
+        /// <value>
+        /// The address.
+        /// </value>
+        string Address { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is bit address.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is bit address; otherwise, <c>false</c>.
+        /// </value>
+        Type TagType { get; }
+
+        /// <summary>
+        /// Gets the name of the tag.
+        /// </summary>
+        /// <value>
+        /// The name of the tag.
+        /// </value>
+        string TagName { get; }
+
+        /// <summary>
+        /// Gets the value.
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
+        object? Value { get; }
+    }
+}

--- a/src/OmronPlcRx/Tags/PlcTag.cs
+++ b/src/OmronPlcRx/Tags/PlcTag.cs
@@ -9,31 +9,25 @@ namespace OmronPlcRx.Tags
     /// PlcTag.
     /// </summary>
     /// <typeparam name="T">The data type.</typeparam>
-    public class PlcTag<T>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="PlcTag{T}"/> class.
+    /// </remarks>
+    /// <param name="tagName">The tag Name.</param>
+    /// <param name="address">The address.</param>
+    /// <exception cref="ArgumentNullException">
+    /// name
+    /// or
+    /// address.
+    /// </exception>
+    public class PlcTag<T>(string tagName, string address) : IPlcTag
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PlcTag{T}"/> class.
-        /// </summary>
-        /// <param name="tagName">The tag Name.</param>
-        /// <param name="address">The address.</param>
-        /// <exception cref="ArgumentNullException">
-        /// name
-        /// or
-        /// address.
-        /// </exception>
-        public PlcTag(string tagName, string address)
-        {
-            TagName = tagName ?? throw new ArgumentNullException(nameof(tagName));
-            Address = address ?? throw new ArgumentNullException(nameof(address));
-        }
-
         /// <summary>
         /// Gets the Tag Name.
         /// </summary>
         /// <value>
         /// The name.
         /// </value>
-        public string TagName { get; }
+        public string TagName { get; } = tagName ?? throw new ArgumentNullException(nameof(tagName));
 
         /// <summary>
         /// Gets the address.
@@ -41,15 +35,7 @@ namespace OmronPlcRx.Tags
         /// <value>
         /// The address.
         /// </value>
-        public string Address { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance is bit address.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is bit address; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsBitAddress => Address.Contains(".");
+        public string Address { get; } = address ?? throw new ArgumentNullException(nameof(address));
 
         /// <summary>
         /// Gets the value read.
@@ -57,14 +43,22 @@ namespace OmronPlcRx.Tags
         /// <value>
         /// The value.
         /// </value>
-        public T Value { get; internal set; }
+        public T? Value { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the value to write.
+        /// Gets a value indicating whether this instance is bit address.
         /// </summary>
         /// <value>
-        /// The write value.
+        ///   <c>true</c> if this instance is bit address; otherwise, <c>false</c>.
         /// </value>
-        public T WriteValue { get; set; }
+        public Type TagType => typeof(T);
+
+        /// <summary>
+        /// Gets the value.
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
+        object? IPlcTag.Value => Value;
     }
 }


### PR DESCRIPTION
Introduces the IPlcTag interface and updates PlcTag<T> to implement it, enabling more type-safe and extensible tag management. Refactors IOmronPlcRx and OmronPlcRx to use IPlcTag for tag observation and notification, improving code clarity and future extensibility. Also adds conditional package references for netstandard2.0 in the project file.