### PR TITLE
Add BCD type support and enhance PLC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,323 @@
-# OmronPlcRx
-A Reactive Omron Plc communications library
+﻿# OmronPlcRx
+
+A Reactive Omron PLC communications library for .NET (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`).
+
+OmronPlcRx provides a high-level, reactive, strongly typed interface for interacting with Omron PLCs over the FINS protocol using TCP or UDP. It handles:
+
+- Connection setup & initialization (controller model / version discovery)
+- Bit and word memory area reads & writes
+- PLC clock & scan cycle time access (now exposed via public wrapper methods)
+- Reactive polling of configured PLC tag addresses
+- Type handling for: `bool`, `byte`, `short`, `ushort`, `int` (2 words), `uint` (2 words), `float` (2 words IEEE 754), `double` (4 words IEEE 754), `string` (variable length, ASCII, packed 2 chars/word), BCD numeric wrappers: `Bcd16`, `BcdU16` (1 word), `Bcd32`, `BcdU32` (2 words)
+- Error propagation via reactive streams
+- Automatic PLC capability limits (read/write length, area availability)
+
+Contents:
+- Features
+- Installation
+- Quick Start
+- Addressing Guide
+- Supported Types & Encoding
+- BCD Types
+- Reactive Tag & System API
+- Code Samples
+- Direct Read/Write Core API Overview
+- PLC Clock & Cycle Time
+- Error Handling
+- PLC Types & Limits
+- FAQ
+- Contributing
+- License / Disclaimer
+
+---
+## Features
+- TCP or UDP transport selection
+- Automatic controller identification (model, version, PLC type classification)
+- Reactive `IObservable<T>` streams per tag and an aggregate stream of all tag changes
+- Background polling loop with configurable interval (default 100 ms)
+- Safe concurrent access with internal caching
+- Strong typing for tag values; built-in conversion for common primitives & BCD wrappers
+- Bit addressing (e.g. `D10.3`, `W100.7`, `CIO200.0`)
+- Word + multi‑word (32/64‑bit) assembly (High word first for multi-word numerics)
+- Public accessors for PLC real-time clock & scan cycle time (`ReadClockAsync`, `WriteClockAsync`, `ReadCycleTimeAsync`)
+- Exception surfacing via `Errors` observable
+- Targets legacy & modern runtimes
+
+---
+## Installation
+NuGet:
+```
+dotnet add package OmronPlcRx
+```
+OR (Package Manager):
+```
+Install-Package OmronPlcRx
+```
+---
+## Quick Start
+```csharp
+using System;
+using System.Reactive.Linq;
+using OmronPlcRx;
+using OmronPlcRx.Enums;
+using OmronPlcRx.Core.Types; // BCD wrappers
+
+class Program
+{
+    static async Task Main()
+    {
+        var plc = new OmronPlcRx.OmronPlcRx(
+            localNodeId: 11,
+            remoteNodeId: 1,
+            connectionMethod: ConnectionMethod.UDP,
+            remoteHost: "192.168.250.1",
+            port: 9600,
+            timeout: 2000,
+            retries: 1,
+            pollInterval: TimeSpan.FromMilliseconds(200));
+
+        // Register tags (variable = PLC address, tagName = logical name)
+        plc.AddUpdateTagItem<bool>("D100.0", "MotorRun");
+        plc.AddUpdateTagItem<short>("D200", "TemperatureRaw");
+        plc.AddUpdateTagItem<int>("D300", "BatchCounter");          // D300,D301
+        plc.AddUpdateTagItem<float>("D400", "TankLevel");            // D400,D401
+        plc.AddUpdateTagItem<double>("D500", "TotalizedFlow");       // D500..D503
+        plc.AddUpdateTagItem<string>("D600[20]", "LineName");        // 20 ASCII chars max (10 words)
+        plc.AddUpdateTagItem<Bcd16>("D700", "BcdTemp");              // 1 word BCD
+        plc.AddUpdateTagItem<Bcd32>("D710", "BcdCount");             // 2 word BCD
+        plc.AddUpdateTagItem<uint>("D720", "UnsignedCounter");       // 2 words
+        plc.AddUpdateTagItem<byte>("D730", "SmallFlagByte");         // stored in low byte of word
+
+        // Observe single tag
+        var sub1 = plc.Observe<bool>("MotorRun")
+            .DistinctUntilChanged()
+            .Subscribe(v => Console.WriteLine($"MotorRun -> {v}"));
+
+        // Observe all tag changes
+        var subAll = plc.ObserveAll
+            .Subscribe(tag => Console.WriteLine($"Tag {tag?.TagName} = {tag?.Value}"));
+
+        // Observe errors
+        var errSub = plc.Errors.Subscribe(e => Console.WriteLine($"ERROR: {e?.Message}"));
+
+        // Write (async fire-and-forget)
+        plc.Value("MotorRun", true);
+        plc.Value("LineName", "Filling Line 1");
+        plc.Value("BcdTemp", new Bcd16(235)); // writes BCD 0235
+
+        // Read last cached value
+        var tempRaw = plc.Value<short>("TemperatureRaw");
+        Console.WriteLine($"Temp raw = {tempRaw}");
+
+        // Direct clock & cycle time access
+        var clock = await plc.ReadClockAsync();
+        Console.WriteLine($"PLC Clock: {clock.Clock:o}");
+        var cycle = await plc.ReadCycleTimeAsync();
+        Console.WriteLine($"Cycle Times: Min={cycle.MinimumCycleTime} Max={cycle.MaximumCycleTime} Avg={cycle.AverageCycleTime}");
+
+        Console.ReadKey();
+        plc.Dispose();
+    }
+}
+```
+
+---
+## Addressing Guide
+Supported memory area prefixes:
+- `D` / `DM` : Data Memory (bits & words)
+- `C` / `CIO` : Common IO area
+- `W` : Work area
+- `H` : Holding area
+- `A` : Auxiliary area (restricted on some models)
+
+Bit address syntax: `<Area><Word>.<Bit>` where Bit = 0..15  
+Examples: `D100.0`, `W50.7`, `CIO200.15`
+
+Word address syntax: `<Area><Word>`  
+Examples: `D200`, `H10`, `CIO500`
+
+String address syntax: `<Area><Word>[<Length>]` (length in characters). Example: `D600[20]` reserves 20 ASCII chars (10 words). If no length specified, default = 16 chars. Strings are ASCII, packed 2 chars per word (high-byte then low-byte). Null padding is applied if shorter.
+
+---
+## Supported Types & Encoding
+| Type | Words | Notes |
+|------|-------|-------|
+| bool | 1 bit or 1 word | If bit address used reads single bit; if word address treats non-zero as true |
+| byte | 1 word | Stored in low byte (high byte = 0). Read masks low 8 bits |
+| short | 1 word | Signed 16-bit |
+| ushort | 1 word | Unsigned 16-bit |
+| int | 2 words | High word first |
+| uint | 2 words | High word first |
+| float | 2 words | IEEE 754 single; word order high/low; bytes swapped for host endianness |
+| double | 4 words | IEEE 754 double; high word first |
+| string | N words | ASCII, 2 chars per word, length via `[len]` suffix (default 16) |
+| Bcd16 / BcdU16 | 1 word | Packed BCD (4 digits max) |
+| Bcd32 / BcdU32 | 2 words | Packed BCD (8 digits max) |
+
+Multi-word numeric order: the library consistently treats the first configured word as the high-order word for 32/64-bit and BCD 32-bit values.
+
+---
+## BCD Types
+BCD wrappers provide type safety and avoid ambiguity with standard binary-coded integer storage.
+
+- `Bcd16` : signed 16-bit decimal (1 word)  
+- `BcdU16`: unsigned 16-bit decimal (1 word)  
+- `Bcd32` : signed 32-bit decimal (2 words, high word first)  
+- `BcdU32`: unsigned 32-bit decimal (2 words)  
+
+Example:
+```csharp
+plc.AddUpdateTagItem<Bcd32>("D800", "BatchNumber");
+plc.Observe<Bcd32>("BatchNumber")
+   .Subscribe(v => Console.WriteLine($"BatchNumber -> {v?.Value}"));
+plc.Value("BatchNumber", new Bcd32(12345678));
+```
+
+---
+## Reactive Tag & System API (`IOmronPlcRx`)
+Methods / Properties:
+- Tag management: `AddUpdateTagItem<T>(variable, tagName)`
+- Tag observation: `IObservable<T?> Observe<T>(tagName)`
+- Aggregated tag stream: `IObservable<IPlcTag?> ObserveAll`
+- Cached value access: `T? Value<T>(tagName)`
+- Async write (fire & forget): `Value<T>(tagName, value)`
+- Error stream: `IObservable<OmronPLCException?> Errors`
+- Disposal state: `bool IsDisposed`
+- PLC identity: `PLCType PLCType`, `ControllerModel`, `ControllerVersion`
+- Clock / cycle time: `ReadClockAsync()`, `WriteClockAsync(DateTime)`, `WriteClockAsync(DateTime,int)`, `ReadCycleTimeAsync()`
+
+Clock/cycle methods return strongly typed result structs (Bytes/Packets sent/received, Duration and payload data).
+
+---
+## Code Samples
+1. Mirror / inverted control
+```csharp
+plc.AddUpdateTagItem<bool>("D10.0", "SourceFlag");
+plc.AddUpdateTagItem<bool>("D11.0", "TargetFlag");
+plc.Observe<bool>("SourceFlag")
+   .DistinctUntilChanged()
+   .Subscribe(v => plc.Value("TargetFlag", !v));
+```
+
+2. Unsigned counter & rollover detection
+```csharp
+plc.AddUpdateTagItem<uint>("D300", "PulseCounter");
+plc.Observe<uint>("PulseCounter")
+   .Pairwise()
+   .Subscribe(p =>
+   {
+       var (prev, curr) = (p.FirstOrDefault(), p.Last());
+       if (curr < prev) Console.WriteLine("Counter rollover detected");
+   });
+```
+
+3. BCD production count
+```csharp
+plc.AddUpdateTagItem<Bcd32>("D500", "ProdCount");
+plc.Observe<Bcd32>("ProdCount")
+   .DistinctUntilChanged()
+   .Subscribe(v => Console.WriteLine($"Production Count = {v?.Value}"));
+```
+
+4. Double precision accumulation
+```csharp
+plc.AddUpdateTagItem<double>("D600", "EnergyKWh");
+plc.Observe<double>("EnergyKWh")
+   .Sample(TimeSpan.FromSeconds(5))
+   .Subscribe(v => Console.WriteLine($"Energy = {v:F3} kWh"));
+```
+
+5. ASCII string with fixed length
+```csharp
+plc.AddUpdateTagItem<string>("D700[16]", "OperatorName");
+plc.Value("OperatorName", "ALICE");
+plc.Observe<string>("OperatorName")
+   .DistinctUntilChanged()
+   .Subscribe(n => Console.WriteLine($"Operator = {n}"));
+```
+
+6. Byte & UShort handling
+```csharp
+plc.AddUpdateTagItem<byte>("D720", "StatusByte");
+plc.AddUpdateTagItem<ushort>("D721", "RawWord");
+plc.Value("StatusByte", (byte)0x3A);
+plc.Value("RawWord", (ushort)1234);
+```
+
+7. Reading the PLC clock & writing adjustments
+```csharp
+var clockResult = await plc.ReadClockAsync();
+Console.WriteLine($"Clock: {clockResult.Clock:o}");
+await plc.WriteClockAsync(DateTime.UtcNow); // sync PLC clock to current time
+```
+
+8. Cycle time monitoring
+```csharp
+var cycle = await plc.ReadCycleTimeAsync();
+Console.WriteLine($"Scan Cycle ms -> Min:{cycle.MinimumCycleTime} Max:{cycle.MaximumCycleTime} Avg:{cycle.AverageCycleTime}");
+```
+
+---
+## Direct Read/Write Core API Overview
+The internal `OmronPLCConnection` (used by the reactive layer) exposes low-level async methods: `ReadBitsAsync`, `ReadWordsAsync`, `WriteBitsAsync`, `WriteWordsAsync`, `ReadClockAsync`, `WriteClockAsync`, `ReadCycleTimeAsync`.
+
+Extend by adding new FINS request/response types under `Core/Requests` & `Core/Responses`.
+
+---
+## PLC Clock & Cycle Time
+Clock & cycle time can be read/written via public async methods:
+```csharp
+var clock = await plc.ReadClockAsync();
+await plc.WriteClockAsync(DateTime.UtcNow);
+var cycle = await plc.ReadCycleTimeAsync();
+```
+Returned structs include transmission statistics and payload data.
+
+---
+## Error Handling
+Operational exceptions (initialization failure, invalid address, read/write errors, unsupported type) are pushed into `Errors`:
+```csharp
+plc.Errors.Subscribe(e => Console.WriteLine($"[PLC ERR] {e?.Message}"));
+```
+Write errors also surface here because `Value<T>(...)` is fire-and-forget.
+
+---
+## PLC Types & Limits
+Controller type is inferred automatically. Impacts maximum read/write word lengths & area availability.
+
+`PLCType` enum includes: `CP1`, `CJ2`, `NJ101`, `NJ301`, `NJ501`, `NX1P2`, `NX102`, `NX701`, `NY512`, `NY532`, `NJ_NX_NY_Series`, `C_Series`, `Unknown`.
+
+---
+## FAQ
+Q: Multi-word numeric reads seem incorrect.  
+A: Ensure the base word matches how the PLC stores multi-word values. Library expects high word first.
+
+Q: String garbage characters?  
+A: Verify length spec `[len]` matches actual reserved word space and encoding is ASCII.
+
+Q: BCD value off?  
+A: Confirm the PLC really stores the value in packed BCD and digits do not exceed capacity (4 or 8 digits).
+
+Q: Change polling interval after creation?  
+A: Not currently. Dispose and recreate with new interval.
+
+Q: Add new areas (e.g., EM / AR)?  
+A: Extend mapping logic in `OmronPlcRx`.
+
+---
+## Contributing
+PRs welcome. Ideas:
+- Additional data types (arrays, DateTime wrapper enhancements)
+- Auto-reconnect & health monitoring
+- Structured logging integration hooks
+
+---
+## License
+MIT License — see `LICENSE`.
+
+---
+## Disclaimer
+Not affiliated with Omron. Use at your own risk. Validate in a safe test environment before deployment to production systems.
+
+---
+**OmronPlcRx** - Empowering Industrial Automation with Reactive Technology ⚡🏭

--- a/src/OmronPlcRx/Core/Requests/FINSRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/FINSRequest.cs
@@ -14,10 +14,10 @@ internal abstract class FINSRequest
 
     protected FINSRequest(OmronPLCConnection plc)
     {
-        if (plc.Channel is TCPChannel)
+        if (plc.Channel is TCPChannel tCPChannel)
         {
-            LocalNodeID = (plc.Channel as TCPChannel).LocalNodeID;
-            RemoteNodeID = (plc.Channel as TCPChannel).RemoteNodeID;
+            LocalNodeID = tCPChannel.LocalNodeID;
+            RemoteNodeID = tCPChannel.RemoteNodeID;
         }
         else
         {

--- a/src/OmronPlcRx/Core/Requests/ReadCPUUnitDataRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadCPUUnitDataRequest.cs
@@ -19,8 +19,5 @@ internal sealed class ReadCPUUnitDataRequest : FINSRequest
         SubFunctionCode = (byte)MachineConfigurationFunctionCode.ReadCPUUnitData,
     };
 
-    protected override List<byte> BuildRequestData() =>
-        [
-            0
-        ];
+    protected override List<byte> BuildRequestData() => [0];
 }

--- a/src/OmronPlcRx/Core/Requests/ReadClockRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadClockRequest.cs
@@ -19,5 +19,5 @@ internal sealed class ReadClockRequest : FINSRequest
         SubFunctionCode = (byte)TimeDataFunctionCode.ReadClock,
     };
 
-    protected override List<byte> BuildRequestData() => new();
+    protected override List<byte> BuildRequestData() => [];
 }

--- a/src/OmronPlcRx/Core/Requests/ReadCycleTimeRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadCycleTimeRequest.cs
@@ -19,13 +19,5 @@ internal sealed class ReadCycleTimeRequest : FINSRequest
         SubFunctionCode = (byte)StatusFunctionCode.ReadCycleTime,
     };
 
-    protected override List<byte> BuildRequestData()
-    {
-        var data = new List<byte>();
-
-        // Read Cycle Time
-        data.Add(01);
-
-        return data;
-    }
+    protected override List<byte> BuildRequestData() => [01]; // Read Cycle Time
 }

--- a/src/OmronPlcRx/Core/Responses/ReadCPUUnitDataResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadCPUUnitDataResponse.cs
@@ -13,14 +13,13 @@ internal static class ReadCPUUnitDataResponse
     internal const int ControllerVersionLength = 20;
     internal const int SystemReservedLength = 40;
     internal const int AreaDataLength = 12;
+    internal const int TotalResponseLength = ControllerModelLength + ControllerVersionLength + SystemReservedLength + AreaDataLength;
 
     internal static CPUUnitDataResult ExtractData(FINSResponse response)
     {
-        var expectedLength = ControllerModelLength + ControllerVersionLength + SystemReservedLength + AreaDataLength;
-
-        if (response.Data?.Length < expectedLength)
+        if (response.Data?.Length < TotalResponseLength)
         {
-            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + expectedLength.ToString() + "'");
+            throw new FINSException("The Response Data Length of '" + response.Data.Length.ToString() + "' was too short - Expecting a Length of '" + TotalResponseLength.ToString() + "'");
         }
 
         var data = response.Data;
@@ -55,7 +54,7 @@ internal static class ReadCPUUnitDataResponse
             return string.Empty;
         }
 
-        return ASCIIEncoding.ASCII.GetString([.. stringBytes]).Trim();
+        return Encoding.ASCII.GetString([.. stringBytes]).Trim();
     }
 
     private static byte[] SubArray(byte[]? data, int index, int length)
@@ -70,7 +69,7 @@ internal static class ReadCPUUnitDataResponse
         return result;
     }
 
-    internal struct CPUUnitDataResult
+    internal record struct CPUUnitDataResult
     {
         internal string ControllerModel;
         internal string ControllerVersion;

--- a/src/OmronPlcRx/Core/Responses/ReadCycleTimeResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadCycleTimeResponse.cs
@@ -58,7 +58,7 @@ internal static class ReadCycleTimeResponse
         return result;
     }
 
-    internal struct CycleTimeResult
+    internal record struct CycleTimeResult
     {
         internal double MinimumCycleTime;
         internal double MaximumCycleTime;

--- a/src/OmronPlcRx/Core/Responses/ReadMemoryAreaWordResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadMemoryAreaWordResponse.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using OmronPlcRx.Core.Requests;
 
 namespace OmronPlcRx.Core.Responses;
@@ -22,8 +20,7 @@ internal static class ReadMemoryAreaWordResponse
         for (int i = 0, w = 0; i < request.Length * 2; i += 2, w++)
         {
             // Data is big-endian per protocol, convert to host order (little-endian)
-            var value = (short)((data![i] << 8) | data[i + 1]);
-            values[w] = value;
+            values[w] = (short)((data![i] << 8) | data[i + 1]);
         }
 
         return values;

--- a/src/OmronPlcRx/Core/Types/Bcd16.cs
+++ b/src/OmronPlcRx/Core/Types/Bcd16.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Core.Types;
+
+/// <summary>
+/// Signed 16-bit BCD numeric wrapper.
+/// </summary>
+public readonly record struct Bcd16
+{
+    /// <summary>Initializes a new instance of the <see cref="Bcd16"/> struct.</summary>
+    /// <param name="value">The signed value.</param>
+    public Bcd16(short value) => Value = value;
+
+    /// <summary>Gets the numeric value.</summary>
+    public short Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString();
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Value.GetHashCode();
+}

--- a/src/OmronPlcRx/Core/Types/Bcd32.cs
+++ b/src/OmronPlcRx/Core/Types/Bcd32.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Core.Types;
+
+/// <summary>
+/// Signed 32-bit BCD numeric wrapper.
+/// </summary>
+public readonly record struct Bcd32
+{
+    /// <summary>Initializes a new instance of the <see cref="Bcd32"/> struct.</summary>
+    /// <param name="value">The signed value.</param>
+    public Bcd32(int value) => Value = value;
+
+    /// <summary>Gets the numeric value.</summary>
+    public int Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString();
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Value.GetHashCode();
+}

--- a/src/OmronPlcRx/Core/Types/BcdU16.cs
+++ b/src/OmronPlcRx/Core/Types/BcdU16.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Core.Types;
+
+/// <summary>
+/// Unsigned 16-bit BCD numeric wrapper.
+/// </summary>
+public readonly record struct BcdU16
+{
+    /// <summary>Initializes a new instance of the <see cref="BcdU16"/> struct.</summary>
+    /// <param name="value">The unsigned value.</param>
+    public BcdU16(ushort value) => Value = value;
+
+    /// <summary>Gets the numeric value.</summary>
+    public ushort Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString();
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Value.GetHashCode();
+}

--- a/src/OmronPlcRx/Core/Types/BcdU32.cs
+++ b/src/OmronPlcRx/Core/Types/BcdU32.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace OmronPlcRx.Core.Types;
+
+/// <summary>
+/// Unsigned 32-bit BCD numeric wrapper.
+/// </summary>
+public readonly record struct BcdU32
+{
+    /// <summary>Initializes a new instance of the <see cref="BcdU32"/> struct.</summary>
+    /// <param name="value">The unsigned value.</param>
+    public BcdU32(uint value) => Value = value;
+
+    /// <summary>Gets the numeric value.</summary>
+    public uint Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString();
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Value.GetHashCode();
+}

--- a/src/OmronPlcRx/OmronPlcRx.cs
+++ b/src/OmronPlcRx/OmronPlcRx.cs
@@ -6,10 +6,14 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using OmronPlcRx.Core;
+using OmronPlcRx.Core.Converters;
+using OmronPlcRx.Core.Types;
 using OmronPlcRx.Enums;
+using OmronPlcRx.Results;
 using OmronPlcRx.Tags;
 
 namespace OmronPlcRx;
@@ -23,7 +27,7 @@ public sealed class OmronPlcRx : IOmronPlcRx
     private readonly OmronPLCConnection _plc;
     private readonly TimeSpan _pollInterval;
     private readonly ConcurrentDictionary<string, ITagEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
-    private readonly ConcurrentDictionary<string, BehaviorSubject<object?>> _subjects = new(StringComparer.OrdinalIgnoreCase); // value is BehaviorSubject<object?>
+    private readonly ConcurrentDictionary<string, BehaviorSubject<object?>> _subjects = new(StringComparer.OrdinalIgnoreCase);
     private readonly Subject<IPlcTag?> _tagChanged = new();
     private readonly Subject<OmronPLCException?> _errors = new();
     private readonly CancellationTokenSource _cts = new();
@@ -74,6 +78,55 @@ public sealed class OmronPlcRx : IOmronPlcRx
 
     /// <inheritdoc />
     public bool IsDisposed => _disposed;
+
+    /// <summary>
+    /// Gets the type of the PLC.
+    /// </summary>
+    /// <value>
+    /// The type of the PLC.
+    /// </value>
+    public PLCType PLCType => _plc.PLCType;
+
+    /// <summary>
+    /// Gets the PLC controller model string.
+    /// </summary>
+    public string? ControllerModel => _plc.ControllerModel;
+
+    /// <summary>
+    /// Gets the PLC controller version string.
+    /// </summary>
+    public string? ControllerVersion => _plc.ControllerVersion;
+
+    /// <summary>
+    /// Reads the PLC real-time clock via the underlying connection.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Clock read result.</returns>
+    public Task<ReadClockResult> ReadClockAsync(CancellationToken cancellationToken = default) => _plc.ReadClockAsync(cancellationToken);
+
+    /// <summary>
+    /// Writes the PLC real-time clock (day-of-week inferred) via the underlying connection.
+    /// </summary>
+    /// <param name="newDateTime">New date/time.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Clock write result.</returns>
+    public Task<WriteClockResult> WriteClockAsync(DateTime newDateTime, CancellationToken cancellationToken = default) => _plc.WriteClockAsync(newDateTime, cancellationToken);
+
+    /// <summary>
+    /// Writes the PLC real-time clock with explicit day-of-week via the underlying connection.
+    /// </summary>
+    /// <param name="newDateTime">New date/time.</param>
+    /// <param name="newDayOfWeek">Day of week (0-6).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Clock write result.</returns>
+    public Task<WriteClockResult> WriteClockAsync(DateTime newDateTime, int newDayOfWeek, CancellationToken cancellationToken = default) => _plc.WriteClockAsync(newDateTime, newDayOfWeek, cancellationToken);
+
+    /// <summary>
+    /// Reads PLC scan cycle time statistics via the underlying connection.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Cycle time statistics.</returns>
+    public Task<ReadCycleTimeResult> ReadCycleTimeAsync(CancellationToken cancellationToken = default) => _plc.ReadCycleTimeAsync(cancellationToken);
 
     /// <inheritdoc />
     public void AddUpdateTagItem<T>(string variable, string tagName)
@@ -194,17 +247,28 @@ public sealed class OmronPlcRx : IOmronPlcRx
 
     private static (string Area, ushort Address, byte? BitIndex) ParseAddress(string address)
     {
-        var dotIndex = address.IndexOf('.');
+        var baseForParse = address;
+        var bracketIndex = baseForParse.IndexOf('[');
+        if (bracketIndex >= 0)
+        {
+            var endBracket = baseForParse.IndexOf(']', bracketIndex + 1);
+            if (endBracket > bracketIndex)
+            {
+                baseForParse = baseForParse.Remove(bracketIndex, endBracket - bracketIndex + 1);
+            }
+        }
+
+        var dotIndex = baseForParse.IndexOf('.');
         string basePart;
         string? bitPart = null;
         if (dotIndex >= 0)
         {
-            basePart = address.Substring(0, dotIndex);
-            bitPart = address[(dotIndex + 1)..];
+            basePart = baseForParse.Substring(0, dotIndex);
+            bitPart = baseForParse[(dotIndex + 1)..];
         }
         else
         {
-            basePart = address;
+            basePart = baseForParse;
         }
 
         byte? bitIndex = null;
@@ -241,6 +305,25 @@ public sealed class OmronPlcRx : IOmronPlcRx
         }
 
         return (area, addr, bitIndex);
+    }
+
+    private static (string BaseAddress, int Length) ExtractStringMeta(string address, int defaultLength = 16)
+    {
+        var bracketIndex = address.IndexOf('[');
+        if (bracketIndex >= 0)
+        {
+            var end = address.IndexOf(']', bracketIndex + 1);
+            if (end > bracketIndex)
+            {
+                var lenPart = address.Substring(bracketIndex + 1, end - bracketIndex - 1);
+                if (int.TryParse(lenPart, out var len) && len > 0)
+                {
+                    return (address.Remove(bracketIndex, end - bracketIndex + 1), len);
+                }
+            }
+        }
+
+        return (address, defaultLength);
     }
 
     private static MemoryBitDataType ToBitType(string area) => area switch
@@ -338,25 +421,82 @@ public sealed class OmronPlcRx : IOmronPlcRx
             return;
         }
 
-        var (area, addr, bitIndex) = ParseAddress(entry.Tag.Address);
+        if (typeof(T) == typeof(string))
+        {
+            var raw = entry.Tag.Address;
+            var (baseAddr, length) = ExtractStringMeta(raw);
+            var (area, addr, bitIndex) = ParseAddress(baseAddr);
+            if (bitIndex != null)
+            {
+                throw new NotSupportedException("Bit indexing not supported for string types.");
+            }
+
+            var str = Convert.ToString(value) ?? string.Empty;
+            var bytes = Encoding.ASCII.GetBytes(str);
+            if (bytes.Length > length)
+            {
+                Array.Resize(ref bytes, length);
+            }
+            else if (bytes.Length < length)
+            {
+                var padded = new byte[length];
+                Array.Copy(bytes, padded, bytes.Length);
+                bytes = padded;
+            }
+
+            // Ensure even length
+            if (bytes.Length % 2 != 0)
+            {
+                Array.Resize(ref bytes, bytes.Length + 1);
+            }
+
+            var wordCount = bytes.Length / 2;
+            var words = new short[wordCount];
+            for (var i = 0; i < wordCount; i++)
+            {
+                var b1 = bytes[i * 2];
+                var b2 = bytes[(i * 2) + 1];
+
+                // Store first char (b1) in high byte for consistency with other multi-byte handling (network big-end assumption)
+                var word = (short)((b1 << 8) | b2);
+                words[i] = word;
+            }
+
+            await _plc.WriteWordsAsync(words, addr, ToWordType(area), ct).ConfigureAwait(false);
+            return;
+        }
+
+        var (area2, addr2, bitIndex2) = ParseAddress(entry.Tag.Address);
 
         if (typeof(T) == typeof(bool))
         {
             var b = Convert.ToBoolean(value);
-            if (bitIndex is null)
+            if (bitIndex2 is null)
             {
                 var wordVal = (short)(b ? 1 : 0);
-                await _plc.WriteWordsAsync([wordVal], addr, ToWordType(area), ct).ConfigureAwait(false);
+                await _plc.WriteWordsAsync([wordVal], addr2, ToWordType(area2), ct).ConfigureAwait(false);
             }
             else
             {
-                await _plc.WriteBitsAsync([b], addr, bitIndex.Value, ToBitType(area), ct).ConfigureAwait(false);
+                await _plc.WriteBitsAsync([b], addr2, bitIndex2.Value, ToBitType(area2), ct).ConfigureAwait(false);
             }
+        }
+        else if (typeof(T) == typeof(byte))
+        {
+            var bv = Convert.ToByte(value);
+            var word = (short)bv; // store in low byte
+            await _plc.WriteWordsAsync([word], addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(ushort))
+        {
+            var us = Convert.ToUInt16(value);
+            var word = unchecked((short)us);
+            await _plc.WriteWordsAsync([word], addr2, ToWordType(area2), ct).ConfigureAwait(false);
         }
         else if (typeof(T) == typeof(short))
         {
             var s = Convert.ToInt16(value);
-            await _plc.WriteWordsAsync([s], addr, ToWordType(area), ct).ConfigureAwait(false);
+            await _plc.WriteWordsAsync([s], addr2, ToWordType(area2), ct).ConfigureAwait(false);
         }
         else if (typeof(T) == typeof(int))
         {
@@ -364,7 +504,15 @@ public sealed class OmronPlcRx : IOmronPlcRx
             var hi = (ushort)((i >> 16) & 0xFFFF);
             var lo = (ushort)(i & 0xFFFF);
             short[] words = [unchecked((short)hi), unchecked((short)lo)];
-            await _plc.WriteWordsAsync(words, addr, ToWordType(area), ct).ConfigureAwait(false);
+            await _plc.WriteWordsAsync(words, addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(uint))
+        {
+            var ui = Convert.ToUInt32(value);
+            var hi = (ushort)((ui >> 16) & 0xFFFF);
+            var lo = (ushort)(ui & 0xFFFF);
+            short[] words = [unchecked((short)hi), unchecked((short)lo)];
+            await _plc.WriteWordsAsync(words, addr2, ToWordType(area2), ct).ConfigureAwait(false);
         }
         else if (typeof(T) == typeof(float))
         {
@@ -378,7 +526,55 @@ public sealed class OmronPlcRx : IOmronPlcRx
             var hi = (ushort)((bytes[0] << 8) | bytes[1]);
             var lo = (ushort)((bytes[2] << 8) | bytes[3]);
             short[] words = [unchecked((short)hi), unchecked((short)lo)];
-            await _plc.WriteWordsAsync(words, addr, ToWordType(area), ct).ConfigureAwait(false);
+            await _plc.WriteWordsAsync(words, addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            var d = Convert.ToDouble(value);
+            var bytes = BitConverter.GetBytes(d);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+
+            var words = new short[4];
+            for (var i = 0; i < 4; i++)
+            {
+                var hiB = bytes[i * 2];
+                var loB = bytes[(i * 2) + 1];
+                var w = (short)((hiB << 8) | loB);
+                words[i] = w;
+            }
+
+            await _plc.WriteWordsAsync(words, addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(Bcd16))
+        {
+            var numeric = ((Bcd16)(object)value).Value;
+            var bcdBytes = BCDConverter.GetBCDBytes(numeric);
+            var word = BitConverter.ToInt16(bcdBytes, 0);
+            await _plc.WriteWordsAsync([word], addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(BcdU16))
+        {
+            var numeric = ((BcdU16)(object)value).Value;
+            var bcdBytes = BCDConverter.GetBCDBytes(numeric);
+            var word = BitConverter.ToInt16(bcdBytes, 0);
+            await _plc.WriteWordsAsync([word], addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(Bcd32))
+        {
+            var numeric = ((Bcd32)(object)value).Value;
+            var bcdWords = BCDConverter.GetBCDWords(numeric);
+            short[] words = [bcdWords[1], bcdWords[0]];
+            await _plc.WriteWordsAsync(words, addr2, ToWordType(area2), ct).ConfigureAwait(false);
+        }
+        else if (typeof(T) == typeof(BcdU32))
+        {
+            var numeric = ((BcdU32)(object)value).Value;
+            var bcdWords = BCDConverter.GetBCDWords(numeric);
+            short[] words = [bcdWords[1], bcdWords[0]];
+            await _plc.WriteWordsAsync(words, addr2, ToWordType(area2), ct).ConfigureAwait(false);
         }
         else
         {
@@ -394,37 +590,92 @@ public sealed class OmronPlcRx : IOmronPlcRx
         /// <inheritdoc />
         public async Task<bool> ReadAsync(OmronPLCConnection plc, CancellationToken ct)
         {
-            var (area, addr, bitIndex) = ParseAddress(Tag.Address);
+            // String handling
+            if (typeof(T) == typeof(string))
+            {
+                var (baseAddr, length) = ExtractStringMeta(Tag.Address);
+                var (area, addr, bitIndex) = ParseAddress(baseAddr);
+                if (bitIndex != null)
+                {
+                    throw new NotSupportedException("Bit indexing not supported for string types.");
+                }
+
+                var wordCount = (length + 1) / 2; // two chars per word
+                var words = await plc.ReadWordsAsync(addr, (ushort)wordCount, ToWordType(area), ct).ConfigureAwait(false);
+                var bytes = new List<byte>(wordCount * 2);
+                for (var i = 0; i < wordCount; i++)
+                {
+                    var w = (ushort)words.Values[i];
+                    bytes.Add((byte)(w >> 8));
+                    bytes.Add((byte)(w & 0xFF));
+                }
+
+                if (bytes.Count > length)
+                {
+                    bytes.RemoveRange(length, bytes.Count - length);
+                }
+
+                // Trim at first null
+                var nullIndex = bytes.IndexOf(0);
+                var arr = (nullIndex >= 0 ? bytes.GetRange(0, nullIndex) : bytes).ToArray();
+                object newStr = Encoding.ASCII.GetString(arr);
+                if (!Equals(newStr, Tag.Value) && Tag is PlcTag<T> plcTagStr)
+                {
+                    plcTagStr.Value = (T)newStr;
+                    return true;
+                }
+
+                return false;
+            }
+
+            var (area2, addr2, bitIndex2) = ParseAddress(Tag.Address);
             object newVal;
             if (typeof(T) == typeof(bool))
             {
-                if (bitIndex is null)
+                if (bitIndex2 is null)
                 {
-                    var word = await plc.ReadWordAsync(addr, ToWordType(area), ct).ConfigureAwait(false);
+                    var word = await plc.ReadWordAsync(addr2, ToWordType(area2), ct).ConfigureAwait(false);
                     newVal = word.Values[0] != 0;
                 }
                 else
                 {
-                    var bits = await plc.ReadBitsAsync(addr, bitIndex.Value, 1, ToBitType(area), ct).ConfigureAwait(false);
+                    var bits = await plc.ReadBitsAsync(addr2, bitIndex2.Value, 1, ToBitType(area2), ct).ConfigureAwait(false);
                     newVal = bits.Values[0];
                 }
             }
             else if (typeof(T) == typeof(short))
             {
-                var words = await plc.ReadWordsAsync(addr, 1, ToWordType(area), ct).ConfigureAwait(false);
+                var words = await plc.ReadWordsAsync(addr2, 1, ToWordType(area2), ct).ConfigureAwait(false);
                 newVal = words.Values[0];
+            }
+            else if (typeof(T) == typeof(byte))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 1, ToWordType(area2), ct).ConfigureAwait(false);
+                newVal = (byte)(words.Values[0] & 0xFF);
+            }
+            else if (typeof(T) == typeof(ushort))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 1, ToWordType(area2), ct).ConfigureAwait(false);
+                newVal = (ushort)words.Values[0];
             }
             else if (typeof(T) == typeof(int))
             {
-                var words = await plc.ReadWordsAsync(addr, 2, ToWordType(area), ct).ConfigureAwait(false);
+                var words = await plc.ReadWordsAsync(addr2, 2, ToWordType(area2), ct).ConfigureAwait(false);
                 var hi = (ushort)words.Values[0];
                 var lo = (ushort)words.Values[1];
                 var composite = ((uint)hi << 16) | lo;
                 newVal = unchecked((int)composite);
             }
+            else if (typeof(T) == typeof(uint))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 2, ToWordType(area2), ct).ConfigureAwait(false);
+                var hi = (uint)(ushort)words.Values[0];
+                var lo = (uint)(ushort)words.Values[1];
+                newVal = (hi << 16) | lo;
+            }
             else if (typeof(T) == typeof(float))
             {
-                var words = await plc.ReadWordsAsync(addr, 2, ToWordType(area), ct).ConfigureAwait(false);
+                var words = await plc.ReadWordsAsync(addr2, 2, ToWordType(area2), ct).ConfigureAwait(false);
                 var hi = (ushort)words.Values[0];
                 var lo = (ushort)words.Values[1];
                 var bytes = new byte[4]
@@ -437,6 +688,54 @@ public sealed class OmronPlcRx : IOmronPlcRx
                 }
 
                 newVal = BitConverter.ToSingle(bytes, 0);
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 4, ToWordType(area2), ct).ConfigureAwait(false);
+                var bytes = new byte[8];
+                for (var i = 0; i < 4; i++)
+                {
+                    var w = (ushort)words.Values[i];
+                    bytes[i * 2] = (byte)(w >> 8);
+                    bytes[(i * 2) + 1] = (byte)(w & 0xFF);
+                }
+
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(bytes);
+                }
+
+                newVal = BitConverter.ToDouble(bytes, 0);
+            }
+            else if (typeof(T) == typeof(Bcd16))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 1, ToWordType(area2), ct).ConfigureAwait(false);
+                var raw = words.Values[0];
+                var val = BCDConverter.ToInt16(raw);
+                newVal = new Bcd16(val);
+            }
+            else if (typeof(T) == typeof(BcdU16))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 1, ToWordType(area2), ct).ConfigureAwait(false);
+                var raw = words.Values[0];
+                var val = BCDConverter.ToUInt16(raw);
+                newVal = new BcdU16(val);
+            }
+            else if (typeof(T) == typeof(Bcd32))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 2, ToWordType(area2), ct).ConfigureAwait(false);
+                var high = words.Values[0];
+                var low = words.Values[1];
+                var val = BCDConverter.ToInt32(low, high);
+                newVal = new Bcd32(val);
+            }
+            else if (typeof(T) == typeof(BcdU32))
+            {
+                var words = await plc.ReadWordsAsync(addr2, 2, ToWordType(area2), ct).ConfigureAwait(false);
+                var high = words.Values[0];
+                var low = words.Values[1];
+                var val = BCDConverter.ToUInt32(low, high);
+                newVal = new BcdU32(val);
             }
             else
             {


### PR DESCRIPTION
Introduces Bcd16, BcdU16, Bcd32, and BcdU32 types for BCD numeric handling. Refactors IOmronPlcRx and OmronPlcRx to expose PLC clock and cycle time methods, improves tag parsing for string and numeric types, and updates request/response logic for consistency. Expands README with comprehensive usage, addressing, and type documentation.