### PR TITLE
Add changelog and release steps to CI workflow

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -25,6 +25,10 @@ jobs:
   windows-latest:
     name: windows-latest
     runs-on: windows-latest
+    
+    permissions: write-all
+    environment:
+      name: release
     steps:
       - uses: actions/checkout@v5
         with:
@@ -62,3 +66,17 @@ jobs:
         with:
           name: output
           path: output
+
+      - name: Changelog
+        uses: glennawatson/ChangeLog@v1
+        id: changelog
+
+      - name: Create Release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ steps.nbgv.outputs.SemVer2 }}
+          release_name: ${{ steps.nbgv.outputs.SemVer2 }}
+          body: |
+            ${{ steps.changelog.outputs.commitLog }}


### PR DESCRIPTION
Introduces changelog generation and automated release creation to the windows-latest job in the BuildDeploy GitHub Actions workflow. Also sets write permissions and specifies the release environment for improved deployment automation.