### PR TITLE
Remove symbol package properties from project file

### DIFF
--- a/src/OmronPlcRx/OmronPlcRx.csproj
+++ b/src/OmronPlcRx/OmronPlcRx.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Deleted IncludeSymbols and SymbolPackageFormat properties from OmronPlcRx.csproj to simplify project configuration.