### PR TITLE
feat: add reactive Omron PLC shared-source package

### DIFF
--- a/CodeCoverage.settings.xml
+++ b/CodeCoverage.settings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*\\OmronPlcRx\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <ModulePath>.*\\OmronPlcRx\.Reactive\.dll$</ModulePath>
+        <ModulePath>.*\\OmronPlcRx\.Tests\.dll$</ModulePath>
+        <ModulePath>.*\\Examples?\\.*</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Sources>
+      <Exclude>
+        <Source>.*\\tests\\.*</Source>
+        <Source>.*\\Tests\\.*</Source>
+        <Source>.*\\examples\\.*</Source>
+        <Source>.*\\Examples\\.*</Source>
+        <Source>.*\\bin\\.*</Source>
+        <Source>.*\\obj\\.*</Source>
+      </Exclude>
+    </Sources>
+    <IncludeTestAssembly>false</IncludeTestAssembly>
+  </CodeCoverage>
+</Configuration>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
     <PackageReference Include="StyleSharp.Analyzers" Version="3.13.4" PrivateAssets="all"/>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/OmronPlcRx.Reactive/OmronPlcRx.Reactive.csproj
+++ b/src/OmronPlcRx.Reactive/OmronPlcRx.Reactive.csproj
@@ -1,14 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net462;net472;net481;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
+    <RootNamespace>OmronPlcRx.Reactive</RootNamespace>
+    <AssemblyName>OmronPlcRx.Reactive</AssemblyName>
+    <PackageId>OmronPlcRx.Reactive</PackageId>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Primitives" Version="5.8.0" ExcludeAssets="analyzers" />
-    <PackageReference Include="ReactiveUI.Primitives.Async" Version="5.8.0" ExcludeAssets="analyzers" />
-    <PackageReference Include="SerialPortRx" Version="5.0.20" ExcludeAssets="analyzers" />
+    <Compile Include="..\OmronPlcRx\**\*.cs"
+             Exclude="..\OmronPlcRx\bin\**;..\OmronPlcRx\obj\**"
+             Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ReactiveUI.Primitives.Reactive" Version="5.8.0" ExcludeAssets="analyzers" />
+    <PackageReference Include="ReactiveUI.Primitives.Async.Reactive" Version="5.8.0" ExcludeAssets="analyzers" />
+    <PackageReference Include="SerialPortRx.Reactive" Version="5.0.20" ExcludeAssets="analyzers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OmronPlcRx.SourceGenerators/PlcTagSourceGenerator.cs
+++ b/src/OmronPlcRx.SourceGenerators/PlcTagSourceGenerator.cs
@@ -19,8 +19,12 @@ namespace OmronPlcRx.SourceGenerators;
 [Generator]
 public sealed class PlcTagSourceGenerator : ISourceGenerator
 {
-    /// <summary>Metadata name for the PLC tag attribute consumed by this generator.</summary>
-    private const string AttributeMetadataName = "OmronPlcRx.PlcTagAttribute";
+    /// <summary>Metadata names for PLC tag attributes consumed by this generator.</summary>
+    private static readonly string[] AttributeMetadataNames =
+    [
+        "OmronPlcRx.PlcTagAttribute",
+        "OmronPlcRx.Reactive.PlcTagAttribute",
+    ];
 
     /// <summary>Format used when generated code needs a fully qualified type name.</summary>
     private static readonly SymbolDisplayFormat FullyQualifiedFormat = SymbolDisplayFormat.FullyQualifiedFormat;
@@ -75,45 +79,63 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
             return;
         }
 
-        var attributeSymbol = context.Compilation.GetTypeByMetadataName(AttributeMetadataName);
-        if (attributeSymbol is null)
+        var attributeSymbols = ResolvePlcTagAttributeSymbols(context.Compilation);
+        if (attributeSymbols.Count == 0)
         {
             return;
         }
 
         var targets = new Dictionary<INamedTypeSymbol, List<TagField>>(SymbolEqualityComparer.Default);
-        CollectTargets(context, receiver.CandidateFields, attributeSymbol, targets);
+        CollectTargets(context, receiver.CandidateFields, attributeSymbols, targets);
         AddGeneratedSources(context, targets);
+    }
+
+    /// <summary>Resolves PLC tag attribute symbols available in the current compilation.</summary>
+    /// <param name="compilation">Current compilation.</param>
+    /// <returns>The resolved PLC tag attribute symbols.</returns>
+    private static List<INamedTypeSymbol> ResolvePlcTagAttributeSymbols(Compilation compilation)
+    {
+        var symbols = new List<INamedTypeSymbol>(AttributeMetadataNames.Length);
+        foreach (var metadataName in AttributeMetadataNames)
+        {
+            var symbol = compilation.GetTypeByMetadataName(metadataName);
+            if (symbol is not null)
+            {
+                symbols.Add(symbol);
+            }
+        }
+
+        return symbols;
     }
 
     /// <summary>Collects all valid PLC tag fields grouped by containing type.</summary>
     /// <param name="context">Current generator execution context.</param>
     /// <param name="fieldDeclarations">Field declarations collected by the syntax receiver.</param>
-    /// <param name="attributeSymbol">Resolved PLC tag attribute symbol.</param>
+    /// <param name="attributeSymbols">Resolved PLC tag attribute symbols.</param>
     /// <param name="targets">Target map to populate.</param>
     private static void CollectTargets(
         GeneratorExecutionContext context,
         IEnumerable<FieldDeclarationSyntax> fieldDeclarations,
-        INamedTypeSymbol attributeSymbol,
+        IReadOnlyCollection<INamedTypeSymbol> attributeSymbols,
         Dictionary<INamedTypeSymbol, List<TagField>> targets)
     {
         foreach (var fieldDeclaration in fieldDeclarations)
         {
             var semanticModel = context.Compilation.GetSemanticModel(fieldDeclaration.SyntaxTree);
-            CollectFields(context, semanticModel, attributeSymbol, fieldDeclaration, targets);
+            CollectFields(context, semanticModel, attributeSymbols, fieldDeclaration, targets);
         }
     }
 
     /// <summary>Collects valid PLC tags from one field declaration.</summary>
     /// <param name="context">Current generator execution context.</param>
     /// <param name="semanticModel">Semantic model for the field declaration.</param>
-    /// <param name="attributeSymbol">Resolved PLC tag attribute symbol.</param>
+    /// <param name="attributeSymbols">Resolved PLC tag attribute symbols.</param>
     /// <param name="fieldDeclaration">Field declaration to inspect.</param>
     /// <param name="targets">Target map to populate.</param>
     private static void CollectFields(
         GeneratorExecutionContext context,
         SemanticModel semanticModel,
-        INamedTypeSymbol attributeSymbol,
+        IReadOnlyCollection<INamedTypeSymbol> attributeSymbols,
         FieldDeclarationSyntax fieldDeclaration,
         Dictionary<INamedTypeSymbol, List<TagField>> targets)
     {
@@ -121,7 +143,7 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
         {
             if (TryCreateTagField(
                 semanticModel,
-                attributeSymbol,
+                attributeSymbols,
                 variable,
                 out var containingType,
                 out var tagField,
@@ -155,7 +177,7 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
 
     /// <summary>Creates a tag field model for one attributed variable.</summary>
     /// <param name="semanticModel">Semantic model used to resolve the field symbol.</param>
-    /// <param name="attributeSymbol">Resolved PLC tag attribute symbol.</param>
+    /// <param name="attributeSymbols">Resolved PLC tag attribute symbols.</param>
     /// <param name="variable">Variable declarator to inspect.</param>
     /// <param name="containingType">Containing type when a tag field is created.</param>
     /// <param name="tagField">Created tag field model.</param>
@@ -163,7 +185,7 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <returns>True when a valid tag field was created; otherwise false.</returns>
     private static bool TryCreateTagField(
         SemanticModel semanticModel,
-        INamedTypeSymbol attributeSymbol,
+        IReadOnlyCollection<INamedTypeSymbol> attributeSymbols,
         VariableDeclaratorSyntax variable,
         out INamedTypeSymbol? containingType,
         out TagField? tagField,
@@ -178,7 +200,7 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
             return false;
         }
 
-        var attributeData = GetPlcTagAttribute(fieldSymbol, attributeSymbol);
+        var attributeData = GetPlcTagAttribute(fieldSymbol, attributeSymbols);
         if (attributeData is null)
         {
             return false;
@@ -198,15 +220,18 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
 
     /// <summary>Finds the PLC tag attribute instance on a field symbol.</summary>
     /// <param name="fieldSymbol">Field symbol to inspect.</param>
-    /// <param name="attributeSymbol">Resolved PLC tag attribute symbol.</param>
+    /// <param name="attributeSymbols">Resolved PLC tag attribute symbols.</param>
     /// <returns>The matching attribute data when present; otherwise null.</returns>
-    private static AttributeData? GetPlcTagAttribute(IFieldSymbol fieldSymbol, INamedTypeSymbol attributeSymbol)
+    private static AttributeData? GetPlcTagAttribute(IFieldSymbol fieldSymbol, IReadOnlyCollection<INamedTypeSymbol> attributeSymbols)
     {
         foreach (var attribute in fieldSymbol.GetAttributes())
         {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeSymbol))
+            foreach (var attributeSymbol in attributeSymbols)
             {
-                return attribute;
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeSymbol))
+                {
+                    return attribute;
+                }
             }
         }
 
@@ -334,11 +359,13 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
         }
 
         var indent = namespaceName is null ? string.Empty : "    ";
+        var plcFacadeType = GetPlcFacadeType(containingType);
+        var observableAsyncBridgeType = GetObservableAsyncBridgeType(containingType);
         AppendTypeStart(builder, indent, containingType);
-        AppendProperties(builder, indent, fields);
-        AppendRegisterMethod(builder, indent + "    ", fields);
-        AppendBindMethod(builder, indent + "    ", fields);
-        AppendWriteMethods(builder, indent, fields);
+        AppendProperties(builder, indent, fields, observableAsyncBridgeType);
+        AppendRegisterMethod(builder, indent + "    ", fields, plcFacadeType);
+        AppendBindMethod(builder, indent + "    ", fields, plcFacadeType);
+        AppendWriteMethods(builder, indent, fields, plcFacadeType);
         AppendLine(builder, indent + "}");
 
         if (namespaceName is not null)
@@ -347,6 +374,37 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>Gets the generated PLC facade type for the target namespace.</summary>
+    /// <param name="containingType">Type receiving generated PLC members.</param>
+    /// <returns>The fully qualified PLC facade type name.</returns>
+    private static string GetPlcFacadeType(INamedTypeSymbol containingType) =>
+        IsReactiveNamespace(containingType)
+            ? "global::OmronPlcRx.Reactive.IOmronPlcRx"
+            : "global::OmronPlcRx.IOmronPlcRx";
+
+    /// <summary>Gets the observable-to-async bridge type for the target namespace.</summary>
+    /// <param name="containingType">Type receiving generated PLC members.</param>
+    /// <returns>The fully qualified bridge type name.</returns>
+    private static string GetObservableAsyncBridgeType(INamedTypeSymbol containingType) =>
+        IsReactiveNamespace(containingType)
+            ? "global::CP.IO.Ports.Reactive.ObservableAsyncBridgeExtensions"
+            : "global::CP.IO.Ports.ObservableAsyncBridgeExtensions";
+
+    /// <summary>Determines whether generated code targets the reactive package namespace.</summary>
+    /// <param name="containingType">Type receiving generated PLC members.</param>
+    /// <returns>True when the containing type lives under <c>OmronPlcRx.Reactive</c>.</returns>
+    private static bool IsReactiveNamespace(INamedTypeSymbol containingType)
+    {
+        if (containingType.ContainingNamespace.IsGlobalNamespace)
+        {
+            return false;
+        }
+
+        var namespaceName = containingType.ContainingNamespace.ToDisplayString();
+        return namespaceName == "OmronPlcRx.Reactive" ||
+            namespaceName.StartsWith("OmronPlcRx.Reactive.", StringComparison.Ordinal);
     }
 
     /// <summary>Appends generated source header and using directives.</summary>
@@ -382,11 +440,12 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Target type indentation.</param>
     /// <param name="fields">Collected tag fields.</param>
-    private static void AppendProperties(StringBuilder builder, string indent, IReadOnlyList<TagField> fields)
+    /// <param name="observableAsyncBridgeType">Fully qualified observable-to-async bridge type.</param>
+    private static void AppendProperties(StringBuilder builder, string indent, IReadOnlyList<TagField> fields, string observableAsyncBridgeType)
     {
         foreach (var field in fields)
         {
-            AppendProperty(builder, indent + "    ", field);
+            AppendProperty(builder, indent + "    ", field, observableAsyncBridgeType);
         }
     }
 
@@ -394,13 +453,14 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Target type indentation.</param>
     /// <param name="fields">Collected tag fields.</param>
-    private static void AppendWriteMethods(StringBuilder builder, string indent, IReadOnlyList<TagField> fields)
+    /// <param name="plcFacadeType">Fully qualified PLC facade type.</param>
+    private static void AppendWriteMethods(StringBuilder builder, string indent, IReadOnlyList<TagField> fields, string plcFacadeType)
     {
         foreach (var field in fields)
         {
             if (field.Writable)
             {
-                AppendWriteMethod(builder, indent + "    ", field);
+                AppendWriteMethod(builder, indent + "    ", field, plcFacadeType);
             }
         }
     }
@@ -409,7 +469,8 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Current indentation.</param>
     /// <param name="field">Tag field to emit.</param>
-    private static void AppendProperty(StringBuilder builder, string indent, TagField field)
+    /// <param name="observableAsyncBridgeType">Fully qualified observable-to-async bridge type.</param>
+    private static void AppendProperty(StringBuilder builder, string indent, TagField field, string observableAsyncBridgeType)
     {
         Append(builder, indent);
         Append(builder, "private readonly global::ReactiveUI.Primitives.Signals.BehaviorSignal<");
@@ -435,7 +496,7 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
         AppendLine(builder, indent + "    }");
         AppendLine(builder, indent + "}");
         AppendLine(builder);
-        AppendObservableProperties(builder, indent, field);
+        AppendObservableProperties(builder, indent, field, observableAsyncBridgeType);
         Append(builder, indent);
         Append(builder, "partial void On");
         Append(builder, field.PropertyName);
@@ -477,7 +538,8 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Current indentation.</param>
     /// <param name="field">Tag field to emit.</param>
-    private static void AppendObservableProperties(StringBuilder builder, string indent, TagField field)
+    /// <param name="observableAsyncBridgeType">Fully qualified observable-to-async bridge type.</param>
+    private static void AppendObservableProperties(StringBuilder builder, string indent, TagField field, string observableAsyncBridgeType)
     {
         Append(builder, indent);
         Append(builder, "public global::System.IObservable<");
@@ -495,7 +557,8 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
         Append(builder, "> ");
         Append(builder, field.PropertyName);
         Append(builder, "ObservableAsync => ");
-        Append(builder, "global::CP.IO.Ports.ObservableAsyncBridgeExtensions.ToObservableAsync(");
+        Append(builder, observableAsyncBridgeType);
+        Append(builder, ".ToObservableAsync(");
         Append(builder, field.PropertyName);
         AppendLine(builder, "Observable);");
         AppendLine(builder, "#endif");
@@ -506,9 +569,10 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Current indentation.</param>
     /// <param name="fields">Collected tag fields.</param>
-    private static void AppendRegisterMethod(StringBuilder builder, string indent, IEnumerable<TagField> fields)
+    /// <param name="plcFacadeType">Fully qualified PLC facade type.</param>
+    private static void AppendRegisterMethod(StringBuilder builder, string indent, IEnumerable<TagField> fields, string plcFacadeType)
     {
-        AppendLine(builder, indent + "public void RegisterPlcTags(global::OmronPlcRx.IOmronPlcRx plc)");
+        AppendLine(builder, indent + "public void RegisterPlcTags(" + plcFacadeType + " plc)");
         AppendLine(builder, indent + "{");
         AppendNullGuard(builder, indent, "plc");
         AppendLine(builder);
@@ -545,9 +609,10 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Current indentation.</param>
     /// <param name="fields">Collected tag fields.</param>
-    private static void AppendBindMethod(StringBuilder builder, string indent, IEnumerable<TagField> fields)
+    /// <param name="plcFacadeType">Fully qualified PLC facade type.</param>
+    private static void AppendBindMethod(StringBuilder builder, string indent, IEnumerable<TagField> fields, string plcFacadeType)
     {
-        AppendLine(builder, indent + "public global::System.IDisposable BindPlcTags(global::OmronPlcRx.IOmronPlcRx plc)");
+        AppendLine(builder, indent + "public global::System.IDisposable BindPlcTags(" + plcFacadeType + " plc)");
         AppendLine(builder, indent + "{");
         AppendNullGuard(builder, indent, "plc");
         AppendLine(builder);
@@ -592,12 +657,15 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
     /// <param name="builder">String builder receiving source text.</param>
     /// <param name="indent">Current indentation.</param>
     /// <param name="field">Writable tag field.</param>
-    private static void AppendWriteMethod(StringBuilder builder, string indent, TagField field)
+    /// <param name="plcFacadeType">Fully qualified PLC facade type.</param>
+    private static void AppendWriteMethod(StringBuilder builder, string indent, TagField field, string plcFacadeType)
     {
         Append(builder, indent);
         Append(builder, "public void Write");
         Append(builder, field.PropertyName);
-        Append(builder, "(global::OmronPlcRx.IOmronPlcRx plc, ");
+        Append(builder, "(");
+        Append(builder, plcFacadeType);
+        Append(builder, " plc, ");
         Append(builder, field.PropertyType);
         AppendLine(builder, " value)");
         AppendLine(builder, indent + "{");
@@ -705,7 +773,11 @@ public sealed class PlcTagSourceGenerator : ISourceGenerator
             "global::OmronPlcRx.Core.Types.Bcd16" or
             "global::OmronPlcRx.Core.Types.BcdU16" or
             "global::OmronPlcRx.Core.Types.Bcd32" or
-            "global::OmronPlcRx.Core.Types.BcdU32";
+            "global::OmronPlcRx.Core.Types.BcdU32" or
+            "global::OmronPlcRx.Reactive.Core.Types.Bcd16" or
+            "global::OmronPlcRx.Reactive.Core.Types.BcdU16" or
+            "global::OmronPlcRx.Reactive.Core.Types.Bcd32" or
+            "global::OmronPlcRx.Reactive.Core.Types.BcdU32";
     }
 
     /// <summary>Determines whether a generated property would collide with an existing member.</summary>

--- a/src/OmronPlcRx.sln
+++ b/src/OmronPlcRx.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OmronPlcRx.SourceGenerators
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OmronPlcRx.Tests", "..\tests\OmronPlcRx.Tests\OmronPlcRx.Tests.csproj", "{9705BA1E-855F-4CE9-B228-D91A76166588}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OmronPlcRx.Reactive", "OmronPlcRx.Reactive\OmronPlcRx.Reactive.csproj", "{80C9857E-754E-4E98-BBB2-3770DFAD20F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +97,18 @@ Global
 		{9705BA1E-855F-4CE9-B228-D91A76166588}.Release|x64.Build.0 = Release|Any CPU
 		{9705BA1E-855F-4CE9-B228-D91A76166588}.Release|x86.ActiveCfg = Release|Any CPU
 		{9705BA1E-855F-4CE9-B228-D91A76166588}.Release|x86.Build.0 = Release|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Release|x64.Build.0 = Release|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{80C9857E-754E-4E98-BBB2-3770DFAD20F5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OmronPlcRx/Async/OmronPlcRxAsyncObservableExtensions.cs
+++ b/src/OmronPlcRx/Async/OmronPlcRxAsyncObservableExtensions.cs
@@ -5,11 +5,20 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+#if REACTIVE_SHIM
+using CP.IO.Ports.Reactive;
+using OmronPlcRx.Reactive.Tags;
+#else
 using CP.IO.Ports;
 using OmronPlcRx.Tags;
+#endif
 using ReactiveUI.Primitives.Async;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Async;
+#else
 namespace OmronPlcRx.Async;
+#endif
 
 /// <summary>Bridges Omron PLC classic Rx streams into ReactiveUI.Primitives.Async observables.</summary>
 public static class OmronPlcRxAsyncObservableExtensions

--- a/src/OmronPlcRx/Core/Channels/BaseChannel.cs
+++ b/src/OmronPlcRx/Core/Channels/BaseChannel.cs
@@ -5,11 +5,21 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Requests;
+using OmronPlcRx.Reactive.Core.Responses;
+using OmronPlcRx.Reactive.Core.Results;
+#else
 using OmronPlcRx.Core.Requests;
 using OmronPlcRx.Core.Responses;
 using OmronPlcRx.Core.Results;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Channels;
+#else
 namespace OmronPlcRx.Core.Channels;
+#endif
 
 /// <summary>Represents the b as ec ha nn el type.</summary>
 internal abstract class BaseChannel : IDisposable

--- a/src/OmronPlcRx/Core/Channels/SerialHostLinkFinsChannel.cs
+++ b/src/OmronPlcRx/Core/Channels/SerialHostLinkFinsChannel.cs
@@ -8,10 +8,19 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using CP.IO.Ports;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Results;
+using SerialPortRx = CP.IO.Ports.Reactive.SerialPortRx;
+#else
 using OmronPlcRx.Core.Results;
+using SerialPortRx = CP.IO.Ports.SerialPortRx;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Channels;
+#else
 namespace OmronPlcRx.Core.Channels;
+#endif
 
 /// <summary>Represents the s er ia lh os tl in kf in sc ha nn el type.</summary>
 internal sealed class SerialHostLinkFinsChannel : BaseChannel

--- a/src/OmronPlcRx/Core/Channels/SerialToolbusFrameBuffer.cs
+++ b/src/OmronPlcRx/Core/Channels/SerialToolbusFrameBuffer.cs
@@ -4,7 +4,11 @@
 
 using System.Collections.Generic;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Channels;
+#else
 namespace OmronPlcRx.Core.Channels;
+#endif
 
 /// <summary>Provides Toolbus serial frame buffer helpers.</summary>
 internal static class SerialToolbusFrameBuffer

--- a/src/OmronPlcRx/Core/Channels/TCPChannel.cs
+++ b/src/OmronPlcRx/Core/Channels/TCPChannel.cs
@@ -6,10 +6,19 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Responses;
+using OmronPlcRx.Reactive.Core.Results;
+#else
 using OmronPlcRx.Core.Responses;
 using OmronPlcRx.Core.Results;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Channels;
+#else
 namespace OmronPlcRx.Core.Channels;
+#endif
 
 /// <summary>Represents the t cp ch an ne l type.</summary>
 internal sealed class TCPChannel : BaseChannel

--- a/src/OmronPlcRx/Core/Channels/UDPChannel.cs
+++ b/src/OmronPlcRx/Core/Channels/UDPChannel.cs
@@ -6,10 +6,19 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Responses;
+using OmronPlcRx.Reactive.Core.Results;
+#else
 using OmronPlcRx.Core.Responses;
 using OmronPlcRx.Core.Results;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Channels;
+#else
 namespace OmronPlcRx.Core.Channels;
+#endif
 
 /// <summary>Represents the u dp ch an ne l type.</summary>
 internal sealed class UDPChannel : BaseChannel

--- a/src/OmronPlcRx/Core/Converters/BCDConverter.cs
+++ b/src/OmronPlcRx/Core/Converters/BCDConverter.cs
@@ -5,7 +5,11 @@
 using System;
 using System.Collections.Generic;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Converters;
+#else
 namespace OmronPlcRx.Core.Converters;
+#endif
 
 /// <summary>Converts between BCD encoded values and numeric values.</summary>
 public static class BCDConverter

--- a/src/OmronPlcRx/Core/Enums/AccessRightsFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/AccessRightsFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the a cc es sr ig ht sf un ct io nc od e enumeration.</summary>
 internal enum AccessRightsFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/DebuggingFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/DebuggingFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the d eb ug gi ng fu nc ti on co de enumeration.</summary>
 internal enum DebuggingFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/ErrorLogFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/ErrorLogFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the e rr or lo gf un ct io nc od e enumeration.</summary>
 internal enum ErrorLogFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/FileMemoryFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/FileMemoryFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents file memory function codes.</summary>
 internal enum FileMemoryFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/FinsWriteLogFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/FinsWriteLogFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the f in sw ri te lo gf un ct io nc od e enumeration.</summary>
 internal enum FinsWriteLogFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/FunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/FunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the f un ct io nc od e enumeration.</summary>
 internal enum FunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/MachineConfigurationFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/MachineConfigurationFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the m ac hi ne co nf ig ur at io nf un ct io nc od e enumeration.</summary>
 internal enum MachineConfigurationFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/MemoryAreaFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/MemoryAreaFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the m em or ya re af un ct io nc od e enumeration.</summary>
 internal enum MemoryAreaFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/MessageDisplayFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/MessageDisplayFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the m es sa ge di sp la yf un ct io nc od e enumeration.</summary>
 internal enum MessageDisplayFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/OperatingModeFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/OperatingModeFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the o pe ra ti ng mo de fu nc ti on co de enumeration.</summary>
 internal enum OperatingModeFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/ParameterAreaFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/ParameterAreaFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the p ar am et er ar ea fu nc ti on co de enumeration.</summary>
 internal enum ParameterAreaFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/ProgramAreaFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/ProgramAreaFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the p ro gr am ar ea fu nc ti on co de enumeration.</summary>
 internal enum ProgramAreaFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/SerialGatewayFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/SerialGatewayFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the s er ia lg at ew ay fu nc ti on co de enumeration.</summary>
 internal enum SerialGatewayFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/StatusFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/StatusFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the s ta tu sf un ct io nc od e enumeration.</summary>
 internal enum StatusFunctionCode : byte

--- a/src/OmronPlcRx/Core/Enums/TimeDataFunctionCode.cs
+++ b/src/OmronPlcRx/Core/Enums/TimeDataFunctionCode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Enums;
+#else
 namespace OmronPlcRx.Core.Enums;
+#endif
 
 /// <summary>Represents the t im ed at af un ct io nc od e enumeration.</summary>
 internal enum TimeDataFunctionCode : byte

--- a/src/OmronPlcRx/Core/OmronPLCConnection.cs
+++ b/src/OmronPlcRx/Core/OmronPLCConnection.cs
@@ -5,13 +5,25 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Channels;
+using OmronPlcRx.Reactive.Core.Requests;
+using OmronPlcRx.Reactive.Core.Responses;
+using OmronPlcRx.Reactive.Enums;
+using OmronPlcRx.Reactive.Results;
+#else
 using OmronPlcRx.Core.Channels;
 using OmronPlcRx.Core.Requests;
 using OmronPlcRx.Core.Responses;
 using OmronPlcRx.Enums;
 using OmronPlcRx.Results;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core;
+#else
 namespace OmronPlcRx.Core;
+#endif
 
 /// <summary>High-level Omron PLC client facilitating initialization and FINS read/write operations over TCP/UDP.</summary>
 internal sealed class OmronPLCConnection : IDisposable
@@ -66,6 +78,61 @@ internal sealed class OmronPLCConnection : IDisposable
             ConnectionMethod.UDP => new UDPChannel(RemoteHost, Port),
             _ => new TCPChannel(RemoteHost, Port),
         };
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="OmronPLCConnection"/> class using an injected channel.</summary>
+    /// <param name="localNodeId">The local FINS node identifier.</param>
+    /// <param name="remoteNodeId">The remote PLC FINS node identifier.</param>
+    /// <param name="connectionMethod">The connection method.</param>
+    /// <param name="remoteHost">The remote host.</param>
+    /// <param name="channel">The injected channel.</param>
+    /// <param name="port">The network port.</param>
+    /// <param name="timeout">The timeout.</param>
+    /// <param name="retries">The retry count.</param>
+    /// <param name="plcType">The PLC type to use for validation.</param>
+    /// <param name="controllerModel">The controller model.</param>
+    /// <param name="controllerVersion">The controller version.</param>
+    /// <param name="isInitialized">A value indicating whether the connection starts initialized.</param>
+    internal OmronPLCConnection(
+        byte localNodeId,
+        byte remoteNodeId,
+        ConnectionMethod connectionMethod,
+        string remoteHost,
+        BaseChannel channel,
+        int port = 9600,
+        int timeout = 2000,
+        int retries = 1,
+        PLCType plcType = PLCType.Unknown,
+        string? controllerModel = null,
+        string? controllerVersion = null,
+        bool isInitialized = true)
+    {
+        OmronPLCConnectionMetadata.ValidateNodeIdentifiers(localNodeId, remoteNodeId, connectionMethod);
+        LocalNodeID = localNodeId;
+        RemoteNodeID = remoteNodeId;
+        ConnectionMethod = connectionMethod;
+        RemoteHost = OmronPLCConnectionMetadata.ValidateRemoteHost(remoteHost);
+        OmronPLCConnectionMetadata.ValidatePort(connectionMethod, port);
+        Port = connectionMethod == ConnectionMethod.Serial ? 0 : port;
+
+        if (timeout <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "The Timeout Value cannot be less than 1");
+        }
+
+        Timeout = timeout;
+
+        if (retries < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(retries), "The Retries Value cannot be Negative");
+        }
+
+        Retries = retries;
+        Channel = channel ?? throw new ArgumentNullException(nameof(channel));
+        PLCType = plcType;
+        ControllerModel = controllerModel;
+        ControllerVersion = controllerVersion;
+        _isInitialized = isInitialized;
     }
 
     /// <summary>Gets the local node id value.</summary>

--- a/src/OmronPlcRx/Core/OmronPLCConnectionMetadata.cs
+++ b/src/OmronPlcRx/Core/OmronPLCConnectionMetadata.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Enums;
+#else
 using OmronPlcRx.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core;
+#else
 namespace OmronPlcRx.Core;
+#endif
 
 /// <summary>Provides validation and metadata helpers for PLC connections.</summary>
 internal static class OmronPLCConnectionMetadata

--- a/src/OmronPlcRx/Core/Requests/FINSRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/FINSRequest.cs
@@ -4,9 +4,17 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Channels;
+#else
 using OmronPlcRx.Core.Channels;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the f in sr eq ue st type.</summary>
 internal abstract class FINSRequest

--- a/src/OmronPlcRx/Core/Requests/ReadCPUUnitDataRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadCPUUnitDataRequest.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+#else
 using OmronPlcRx.Core.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the r ea dc pu un it da ta re qu es t type.</summary>
 internal sealed class ReadCPUUnitDataRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/ReadClockRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadClockRequest.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+#else
 using OmronPlcRx.Core.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the r ea dc lo ck re qu es t type.</summary>
 internal sealed class ReadClockRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/ReadCycleTimeRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadCycleTimeRequest.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+#else
 using OmronPlcRx.Core.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the r ea dc yc le ti me re qu es t type.</summary>
 internal sealed class ReadCycleTimeRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/ReadMemoryAreaBitRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadMemoryAreaBitRequest.cs
@@ -4,10 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+using OmronPlcRx.Reactive.Enums;
+#else
 using OmronPlcRx.Core.Enums;
 using OmronPlcRx.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the r ea dm em or ya re ab it re qu es t type.</summary>
 internal sealed class ReadMemoryAreaBitRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/ReadMemoryAreaWordRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/ReadMemoryAreaWordRequest.cs
@@ -4,10 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+using OmronPlcRx.Reactive.Enums;
+#else
 using OmronPlcRx.Core.Enums;
 using OmronPlcRx.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the r ea dm em or ya re aw or dr eq ue st type.</summary>
 internal sealed class ReadMemoryAreaWordRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/WriteClockRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/WriteClockRequest.cs
@@ -4,10 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Converters;
+using OmronPlcRx.Reactive.Core.Enums;
+#else
 using OmronPlcRx.Core.Converters;
 using OmronPlcRx.Core.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the w ri te cl oc kr eq ue st type.</summary>
 internal sealed class WriteClockRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/WriteMemoryAreaBitRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/WriteMemoryAreaBitRequest.cs
@@ -4,10 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+using OmronPlcRx.Reactive.Enums;
+#else
 using OmronPlcRx.Core.Enums;
 using OmronPlcRx.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the w ri te me mo ry ar ea bi tr eq ue st type.</summary>
 internal sealed class WriteMemoryAreaBitRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Requests/WriteMemoryAreaWordRequest.cs
+++ b/src/OmronPlcRx/Core/Requests/WriteMemoryAreaWordRequest.cs
@@ -4,10 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+using OmronPlcRx.Reactive.Enums;
+#else
 using OmronPlcRx.Core.Enums;
 using OmronPlcRx.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Requests;
+#else
 namespace OmronPlcRx.Core.Requests;
+#endif
 
 /// <summary>Represents the w ri te me mo ry ar ea wo rd re qu es t type.</summary>
 internal sealed class WriteMemoryAreaWordRequest : FINSRequest

--- a/src/OmronPlcRx/Core/Responses/FINSResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/FINSResponse.cs
@@ -4,10 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Enums;
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Enums;
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the f in sr es po ns e type.</summary>
 internal sealed class FINSResponse

--- a/src/OmronPlcRx/Core/Responses/ReadCPUUnitDataResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadCPUUnitDataResponse.cs
@@ -6,7 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the r ea dc pu un it da ta re sp on se type.</summary>
 internal static class ReadCPUUnitDataResponse

--- a/src/OmronPlcRx/Core/Responses/ReadClockResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadClockResponse.cs
@@ -3,10 +3,19 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Converters;
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Converters;
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the r ea dc lo ck re sp on se type.</summary>
 internal static class ReadClockResponse

--- a/src/OmronPlcRx/Core/Responses/ReadCycleTimeResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadCycleTimeResponse.cs
@@ -3,10 +3,19 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Converters;
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Converters;
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the r ea dc yc le ti me re sp on se type.</summary>
 internal static class ReadCycleTimeResponse

--- a/src/OmronPlcRx/Core/Responses/ReadMemoryAreaBitResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadMemoryAreaBitResponse.cs
@@ -2,9 +2,17 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the r ea dm em or ya re ab it re sp on se type.</summary>
 internal static class ReadMemoryAreaBitResponse

--- a/src/OmronPlcRx/Core/Responses/ReadMemoryAreaWordResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/ReadMemoryAreaWordResponse.cs
@@ -2,9 +2,17 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the r ea dm em or ya re aw or dr es po ns e type.</summary>
 internal static class ReadMemoryAreaWordResponse

--- a/src/OmronPlcRx/Core/Responses/WriteClockResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/WriteClockResponse.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the w ri te cl oc kr es po ns e type.</summary>
 internal static class WriteClockResponse

--- a/src/OmronPlcRx/Core/Responses/WriteMemoryAreaBitResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/WriteMemoryAreaBitResponse.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the w ri te me mo ry ar ea bi tr es po ns e type.</summary>
 internal static class WriteMemoryAreaBitResponse

--- a/src/OmronPlcRx/Core/Responses/WriteMemoryAreaWordResponse.cs
+++ b/src/OmronPlcRx/Core/Responses/WriteMemoryAreaWordResponse.cs
@@ -3,9 +3,17 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Requests;
+#else
 using OmronPlcRx.Core.Requests;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Responses;
+#else
 namespace OmronPlcRx.Core.Responses;
+#endif
 
 /// <summary>Represents the w ri te me mo ry ar ea wo rd re sp on se type.</summary>
 internal static class WriteMemoryAreaWordResponse

--- a/src/OmronPlcRx/Core/Results/ProcessRequestResult.cs
+++ b/src/OmronPlcRx/Core/Results/ProcessRequestResult.cs
@@ -2,9 +2,17 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core.Responses;
+#else
 using OmronPlcRx.Core.Responses;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Results;
+#else
 namespace OmronPlcRx.Core.Results;
+#endif
 
 /// <summary>Represents the p ro ce ss re qu es tr es ul t type.</summary>
 internal readonly record struct ProcessRequestResult

--- a/src/OmronPlcRx/Core/Results/ReceiveMessageResult.cs
+++ b/src/OmronPlcRx/Core/Results/ReceiveMessageResult.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Results;
+#else
 namespace OmronPlcRx.Core.Results;
+#endif
 
 /// <summary>Represents the r ec ei ve me ss ag er es ul t type.</summary>
 internal readonly record struct ReceiveMessageResult

--- a/src/OmronPlcRx/Core/Results/SendMessageResult.cs
+++ b/src/OmronPlcRx/Core/Results/SendMessageResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Results;
+#else
 namespace OmronPlcRx.Core.Results;
+#endif
 
 /// <summary>Represents the s en dm es sa ge re su lt type.</summary>
 internal readonly record struct SendMessageResult

--- a/src/OmronPlcRx/Core/SocketOperationCleanup.cs
+++ b/src/OmronPlcRx/Core/SocketOperationCleanup.cs
@@ -7,7 +7,11 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core;
+#else
 namespace OmronPlcRx.Core;
+#endif
 
 /// <summary>Provides cleanup helpers for timed socket operations.</summary>
 internal static class SocketOperationCleanup

--- a/src/OmronPlcRx/Core/TcpClient.cs
+++ b/src/OmronPlcRx/Core/TcpClient.cs
@@ -8,7 +8,11 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core;
+#else
 namespace OmronPlcRx.Core;
+#endif
 
 /// <summary>
 /// TCP socket client wrapper providing connect, send and receive operations with timeout and cancellation support across multiple target frameworks.

--- a/src/OmronPlcRx/Core/TcpSocketConfiguration.cs
+++ b/src/OmronPlcRx/Core/TcpSocketConfiguration.cs
@@ -6,7 +6,11 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core;
+#else
 namespace OmronPlcRx.Core;
+#endif
 
 /// <summary>Provides TCP socket setup helpers.</summary>
 internal static class TcpSocketConfiguration

--- a/src/OmronPlcRx/Core/Types/Bcd16.cs
+++ b/src/OmronPlcRx/Core/Types/Bcd16.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Types;
+#else
 namespace OmronPlcRx.Core.Types;
+#endif
 
 /// <summary>Signed 16-bit BCD numeric wrapper.</summary>
 public readonly record struct Bcd16

--- a/src/OmronPlcRx/Core/Types/Bcd32.cs
+++ b/src/OmronPlcRx/Core/Types/Bcd32.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Types;
+#else
 namespace OmronPlcRx.Core.Types;
+#endif
 
 /// <summary>Signed 32-bit BCD numeric wrapper.</summary>
 public readonly record struct Bcd32

--- a/src/OmronPlcRx/Core/Types/BcdU16.cs
+++ b/src/OmronPlcRx/Core/Types/BcdU16.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Types;
+#else
 namespace OmronPlcRx.Core.Types;
+#endif
 
 /// <summary>Unsigned 16-bit BCD numeric wrapper.</summary>
 public readonly record struct BcdU16

--- a/src/OmronPlcRx/Core/Types/BcdU32.cs
+++ b/src/OmronPlcRx/Core/Types/BcdU32.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core.Types;
+#else
 namespace OmronPlcRx.Core.Types;
+#endif
 
 /// <summary>Unsigned 32-bit BCD numeric wrapper.</summary>
 public readonly record struct BcdU32

--- a/src/OmronPlcRx/Core/UdpClient.cs
+++ b/src/OmronPlcRx/Core/UdpClient.cs
@@ -8,7 +8,11 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Core;
+#else
 namespace OmronPlcRx.Core;
+#endif
 
 /// <summary>
 /// UDP socket client wrapper providing send and receive operations with timeout and cancellation support across multiple target frameworks.

--- a/src/OmronPlcRx/Enums/ConnectionMethod.cs
+++ b/src/OmronPlcRx/Enums/ConnectionMethod.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Enums;
+#else
 namespace OmronPlcRx.Enums;
+#endif
 
 /// <summary>Transport protocol used for communication with the PLC.</summary>
 public enum ConnectionMethod

--- a/src/OmronPlcRx/Enums/MemoryBitDataType.cs
+++ b/src/OmronPlcRx/Enums/MemoryBitDataType.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Enums;
+#else
 namespace OmronPlcRx.Enums;
+#endif
 
 /// <summary>Bit-addressable PLC memory areas.</summary>
 public enum MemoryBitDataType

--- a/src/OmronPlcRx/Enums/MemoryWordDataType.cs
+++ b/src/OmronPlcRx/Enums/MemoryWordDataType.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Enums;
+#else
 namespace OmronPlcRx.Enums;
+#endif
 
 /// <summary>Word-addressable PLC memory areas.</summary>
 public enum MemoryWordDataType

--- a/src/OmronPlcRx/Enums/PLCType.cs
+++ b/src/OmronPlcRx/Enums/PLCType.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Enums;
+#else
 namespace OmronPlcRx.Enums;
+#endif
 
 /// <summary>Supported Omron PLC types used to adjust message capabilities and limits.</summary>
 public enum PLCType

--- a/src/OmronPlcRx/FINSException.cs
+++ b/src/OmronPlcRx/FINSException.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>An exception that represents a FINS protocol error or invalid response.</summary>
 public class FINSException : Exception

--- a/src/OmronPlcRx/HostLinkFinsFrameCodec.cs
+++ b/src/OmronPlcRx/HostLinkFinsFrameCodec.cs
@@ -6,7 +6,11 @@ using System;
 using System.Globalization;
 using System.Text;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Encodes and decodes Omron FINS frames carried in Host Link serial frames.</summary>
 public sealed class HostLinkFinsFrameCodec

--- a/src/OmronPlcRx/IOmronPlcRx.cs
+++ b/src/OmronPlcRx/IOmronPlcRx.cs
@@ -5,12 +5,22 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Enums;
+using OmronPlcRx.Reactive.Results;
+using OmronPlcRx.Reactive.Tags;
+#else
 using OmronPlcRx.Enums;
 using OmronPlcRx.Results;
 using OmronPlcRx.Tags;
+#endif
 using ReactiveUI.Primitives.Disposables;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Defines high-level Omron PLC operations and tag access.</summary>
 public interface IOmronPlcRx : IsDisposed

--- a/src/OmronPlcRx/OmronHostLinkFinsFrameMode.cs
+++ b/src/OmronPlcRx/OmronHostLinkFinsFrameMode.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Specifies the Host Link FINS frame layout used over serial communications.</summary>
 public enum OmronHostLinkFinsFrameMode

--- a/src/OmronPlcRx/OmronPLCException.cs
+++ b/src/OmronPlcRx/OmronPLCException.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Represents errors that occur during Omron PLC communication or processing.</summary>
 public class OmronPLCException : Exception

--- a/src/OmronPlcRx/OmronPlcRx.cs
+++ b/src/OmronPlcRx/OmronPlcRx.cs
@@ -7,14 +7,25 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core;
+using OmronPlcRx.Reactive.Enums;
+using OmronPlcRx.Reactive.Results;
+using OmronPlcRx.Reactive.Tags;
+#else
 using OmronPlcRx.Core;
 using OmronPlcRx.Enums;
 using OmronPlcRx.Results;
 using OmronPlcRx.Tags;
+#endif
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>
 /// Reactive wrapper providing typed tag storage, polling and observation for an <see cref="OmronPLCConnection"/> instance.

--- a/src/OmronPlcRx/OmronSerialOptions.cs
+++ b/src/OmronPlcRx/OmronSerialOptions.cs
@@ -5,7 +5,11 @@
 using System;
 using System.IO.Ports;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Gets or sets the omron serial options value.</summary>
 public sealed record OmronSerialOptions

--- a/src/OmronPlcRx/OmronSerialProtocol.cs
+++ b/src/OmronPlcRx/OmronSerialProtocol.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Specifies the serial protocol used to carry FINS messages.</summary>
 public enum OmronSerialProtocol

--- a/src/OmronPlcRx/PlcTagValueCodec.cs
+++ b/src/OmronPlcRx/PlcTagValueCodec.cs
@@ -7,12 +7,23 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+#if REACTIVE_SHIM
+using OmronPlcRx.Reactive.Core;
+using OmronPlcRx.Reactive.Core.Converters;
+using OmronPlcRx.Reactive.Core.Types;
+using OmronPlcRx.Reactive.Enums;
+#else
 using OmronPlcRx.Core;
 using OmronPlcRx.Core.Converters;
 using OmronPlcRx.Core.Types;
 using OmronPlcRx.Enums;
+#endif
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Converts tag values to and from PLC word representations.</summary>
 internal static class PlcTagValueCodec

--- a/src/OmronPlcRx/Results/ReadBitsResult.cs
+++ b/src/OmronPlcRx/Results/ReadBitsResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Read Bits operation.</summary>
 public readonly record struct ReadBitsResult

--- a/src/OmronPlcRx/Results/ReadClockResult.cs
+++ b/src/OmronPlcRx/Results/ReadClockResult.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Read Clock operation.</summary>
 public readonly record struct ReadClockResult

--- a/src/OmronPlcRx/Results/ReadCycleTimeResult.cs
+++ b/src/OmronPlcRx/Results/ReadCycleTimeResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Read Cycle Time operation.</summary>
 public readonly record struct ReadCycleTimeResult

--- a/src/OmronPlcRx/Results/ReadWordsResult.cs
+++ b/src/OmronPlcRx/Results/ReadWordsResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Read Words operation.</summary>
 public readonly record struct ReadWordsResult

--- a/src/OmronPlcRx/Results/WriteBitsResult.cs
+++ b/src/OmronPlcRx/Results/WriteBitsResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Write Bits operation.</summary>
 public readonly record struct WriteBitsResult

--- a/src/OmronPlcRx/Results/WriteClockResult.cs
+++ b/src/OmronPlcRx/Results/WriteClockResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Write Clock operation.</summary>
 public readonly record struct WriteClockResult

--- a/src/OmronPlcRx/Results/WriteWordsResult.cs
+++ b/src/OmronPlcRx/Results/WriteWordsResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Results;
+#else
 namespace OmronPlcRx.Results;
+#endif
 
 /// <summary>Result of a Write Words operation.</summary>
 public readonly record struct WriteWordsResult

--- a/src/OmronPlcRx/SourceGeneration/PlcTagAttribute.cs
+++ b/src/OmronPlcRx/SourceGeneration/PlcTagAttribute.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Marks a field for PLC reactive stream source generation.</summary>
 /// <param name="address">The a dd re ss value.</param>

--- a/src/OmronPlcRx/Tags/IPlcTag.cs
+++ b/src/OmronPlcRx/Tags/IPlcTag.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Tags;
+#else
 namespace OmronPlcRx.Tags;
+#endif
 
 /// <summary>Defines metadata and value access for a PLC tag.</summary>
 public interface IPlcTag

--- a/src/OmronPlcRx/Tags/PlcTag.cs
+++ b/src/OmronPlcRx/Tags/PlcTag.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive.Tags;
+#else
 namespace OmronPlcRx.Tags;
+#endif
 
 /// <summary>Represents a typed PLC tag binding.</summary>
 /// <typeparam name="T">The data type.</typeparam>

--- a/src/OmronPlcRx/ToolbusFinsFrameCodec.cs
+++ b/src/OmronPlcRx/ToolbusFinsFrameCodec.cs
@@ -4,7 +4,11 @@
 
 using System;
 
+#if REACTIVE_SHIM
+namespace OmronPlcRx.Reactive;
+#else
 namespace OmronPlcRx;
+#endif
 
 /// <summary>Encodes and decodes Omron Toolbus serial frames carrying binary FINS messages.</summary>
 public static class ToolbusFinsFrameCodec

--- a/tests/OmronPlcRx.Tests/CoreProtocolCoverageTests.cs
+++ b/tests/OmronPlcRx.Tests/CoreProtocolCoverageTests.cs
@@ -1,0 +1,960 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using OmronPlcRx.Core;
+using OmronPlcRx.Core.Channels;
+using OmronPlcRx.Core.Converters;
+using OmronPlcRx.Core.Requests;
+using OmronPlcRx.Core.Responses;
+using OmronPlcRx.Core.Results;
+using OmronPlcRx.Core.Types;
+using OmronPlcRx.Enums;
+using OmronPlcRx.Results;
+using OmronPlcRx.Tags;
+using TUnit.Core;
+using CoreTcpClient = OmronPlcRx.Core.TcpClient;
+using CoreUdpClient = OmronPlcRx.Core.UdpClient;
+using NetTcpListener = System.Net.Sockets.TcpListener;
+using NetUdpClient = System.Net.Sockets.UdpClient;
+
+namespace OmronPlcRx.Tests;
+
+/// <summary>Tests deterministic protocol, conversion and validation paths.</summary>
+public sealed class CoreProtocolCoverageTests
+{
+    /// <summary>Verifies BCD conversion round trips supported scalar widths.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task BcdConverter_RoundTripsSupportedScalarWidths()
+    {
+        var bcd16 = BCDConverter.GetBCDWord((short)1234);
+        var bcdU16 = BCDConverter.GetBCDWord((ushort)9876);
+        var bcd32 = BCDConverter.GetBCDWords(12_345_678);
+        var bcdU32 = BCDConverter.GetBCDWords(87_654_321u);
+
+        await Assert.That(BCDConverter.ToByte(0x45)).IsEqualTo((byte)45);
+        await Assert.That(BCDConverter.GetBCDByte(45)).IsEqualTo((byte)0x45);
+        await Assert.That(BCDConverter.ToInt16(bcd16)).IsEqualTo((short)1234);
+        await Assert.That(BCDConverter.ToUInt16(bcdU16)).IsEqualTo((ushort)9876);
+        await Assert.That(BCDConverter.ToInt32(bcd32[0], bcd32[1])).IsEqualTo(12_345_678);
+        await Assert.That(BCDConverter.ToUInt32(bcdU32[0], bcdU32[1])).IsEqualTo(87_654_321u);
+        await Assert.That(Convert.ToHexString(BCDConverter.GetBCDBytes((short)1234))).IsEqualTo("3412");
+        await Assert.That(Convert.ToHexString(BCDConverter.GetBCDBytes((ushort)1234))).IsEqualTo("3412");
+        await Assert.That(Convert.ToHexString(BCDConverter.GetBCDBytes(12_345_678))).IsEqualTo("78563412");
+        await Assert.That(Convert.ToHexString(BCDConverter.GetBCDBytes(12_345_678u))).IsEqualTo("78563412");
+    }
+
+    /// <summary>Verifies BCD conversion validates null and invalid byte lengths.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task BcdConverter_RejectsInvalidByteInputs()
+    {
+        await Assert.That(CaptureException<ArgumentNullException>(() => BCDConverter.ToInt16(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => BCDConverter.ToInt16([]))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => BCDConverter.ToUInt16(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => BCDConverter.ToUInt16([0x12]))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => BCDConverter.ToInt32(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => BCDConverter.ToInt32([0x12, 0x34]))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => BCDConverter.ToUInt32(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => BCDConverter.ToUInt32([0x12, 0x34, 0x56]))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => BCDConverter.ToUInt32([0x12, 0x34, 0x56, 0x78, 0x90]))).IsNotNull();
+    }
+
+    /// <summary>Verifies PLC tag values convert to write words and back to typed read values.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task PlcTagValueCodec_ConvertsSupportedWordTypes()
+    {
+        await Assert.That(PlcTagValueCodec.TryGetSingleWord(typeof(byte), (byte)12, out var byteWord)).IsTrue();
+        await Assert.That(byteWord).IsEqualTo((short)12);
+        await Assert.That(PlcTagValueCodec.TryGetSingleWord(typeof(ushort), (ushort)0xFEDC, out var ushortWord)).IsTrue();
+        await Assert.That(Convert.ToHexString(BitConverter.GetBytes(ushortWord))).IsEqualTo("DCFE");
+        await Assert.That(PlcTagValueCodec.TryGetSingleWord(typeof(short), (short)-7, out var shortWord)).IsTrue();
+        await Assert.That(shortWord).IsEqualTo((short)-7);
+        await Assert.That(PlcTagValueCodec.TryGetSingleWord(typeof(Bcd16), new Bcd16(1234), out var bcd16Word)).IsTrue();
+        await Assert.That(BCDConverter.ToInt16(bcd16Word)).IsEqualTo((short)1234);
+        await Assert.That(PlcTagValueCodec.TryGetSingleWord(typeof(BcdU16), new BcdU16(9876), out var bcdU16Word)).IsTrue();
+        await Assert.That(BCDConverter.ToUInt16(bcdU16Word)).IsEqualTo((ushort)9876);
+        await Assert.That(PlcTagValueCodec.TryGetSingleWord(typeof(string), "x", out _)).IsFalse();
+
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(int), 0x12345678, out var intWords)).IsTrue();
+        await Assert.That(PlcTagValueCodec.ConvertReadWords(typeof(int), intWords)).IsEqualTo(0x12345678);
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(uint), 0x89ABCDEFu, out var uintWords)).IsTrue();
+        await Assert.That(PlcTagValueCodec.ConvertReadWords(typeof(uint), uintWords)).IsEqualTo(0x89ABCDEFu);
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(float), 123.5f, out var floatWords)).IsTrue();
+        await Assert.That(PlcTagValueCodec.ConvertReadWords(typeof(float), floatWords)).IsEqualTo(123.5f);
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(double), 123.5d, out var doubleWords)).IsTrue();
+        await Assert.That(PlcTagValueCodec.ConvertReadWords(typeof(double), doubleWords)).IsEqualTo(123.5d);
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(Bcd32), new Bcd32(12_345_678), out var bcd32Words)).IsTrue();
+        await Assert.That(((Bcd32)PlcTagValueCodec.ConvertReadWords(typeof(Bcd32), bcd32Words)).Value).IsEqualTo(12_345_678);
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(BcdU32), new BcdU32(87_654_321), out var bcdU32Words)).IsTrue();
+        await Assert.That(((BcdU32)PlcTagValueCodec.ConvertReadWords(typeof(BcdU32), bcdU32Words)).Value).IsEqualTo(87_654_321u);
+        await Assert.That(PlcTagValueCodec.TryGetWordArray(typeof(string), "x", out _)).IsFalse();
+    }
+
+    /// <summary>Verifies PLC tag string conversions handle null padding and length trimming.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task PlcTagValueCodec_ConvertsStringsAndReadWordCounts()
+    {
+        var words = PlcTagValueCodec.GetStringWords("ABCD", 5);
+
+        await Assert.That(Convert.ToHexString(ToBigEndianBytes(words))).IsEqualTo("414243440000");
+        await Assert.That(PlcTagValueCodec.GetStringFromWords(words, 5, 3)).IsEqualTo("ABCD");
+        await Assert.That(PlcTagValueCodec.GetStringFromWords([(short)0x4142, (short)0x4344], 3, 2)).IsEqualTo("ABC");
+        await Assert.That(PlcTagValueCodec.GetReadWordCount(typeof(short))).IsEqualTo(1);
+        await Assert.That(PlcTagValueCodec.GetReadWordCount(typeof(double))).IsEqualTo(4);
+        await Assert.That(PlcTagValueCodec.GetReadWordCount(typeof(string))).IsEqualTo(0);
+        await Assert.That(CaptureException<NotSupportedException>(() => PlcTagValueCodec.ThrowIfBitIndexedString(1))).IsNotNull();
+        await Assert.That(CaptureException<NotSupportedException>(() => PlcTagValueCodec.ConvertReadWords(typeof(decimal), [1]))).IsNotNull();
+    }
+
+    /// <summary>Verifies internal FINS request builders produce stable protocol bytes.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task FinsRequests_BuildExpectedMessageBytes()
+    {
+        using var plc = CreateConnection();
+        var readWords = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 2, MemoryWordDataType.DataMemory);
+        var writeWords = WriteMemoryAreaWordRequest.CreateNew(plc, 100, MemoryWordDataType.DataMemory, [0x1234, -2]);
+        var readBits = ReadMemoryAreaBitRequest.CreateNew(plc, 100, 3, 2, MemoryBitDataType.CommonIO);
+        var writeBits = WriteMemoryAreaBitRequest.CreateNew(plc, 100, 3, MemoryBitDataType.CommonIO, [true, false, true]);
+        var writeClock = WriteClockRequest.CreateNew(plc, new DateTime(2026, 6, 30, 14, 25, 59), 2);
+
+        await Assert.That(ToHex(readWords.BuildMessage(0x44))).IsEqualTo("800002000200000100440101820064000002");
+        await Assert.That(ToHex(writeWords.BuildMessage(0x45))).IsEqualTo("8000020002000001004501028200640000021234FFFE");
+        await Assert.That(ToHex(readBits.BuildMessage(0x46))).IsEqualTo("800002000200000100460101300064030002");
+        await Assert.That(ToHex(writeBits.BuildMessage(0x47))).IsEqualTo("800002000200000100470102300064030003010001");
+        await Assert.That(ToHex(writeClock.BuildMessage(0x48))).IsEqualTo("80000200020000010048070226063014255902");
+    }
+
+    /// <summary>Verifies FINS response creation validates and extracts response payload data.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task FinsResponses_ValidateAndExtractPayloads()
+    {
+        using var plc = CreateConnection();
+        var readWords = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 2, MemoryWordDataType.DataMemory);
+        _ = readWords.BuildMessage(0x51);
+        var wordResponse = CreateResponse(readWords, [0x12, 0x34, 0xFF, 0xFE]);
+
+        var readBits = ReadMemoryAreaBitRequest.CreateNew(plc, 100, 0, 3, MemoryBitDataType.CommonIO);
+        _ = readBits.BuildMessage(0x52);
+        var bitResponse = CreateResponse(readBits, [1, 0, 2]);
+
+        var readClock = ReadClockRequest.CreateNew(plc);
+        _ = readClock.BuildMessage(0x53);
+        var clock = ReadClockResponse.ExtractClock(readClock, CreateResponse(readClock, [0x26, 0x06, 0x30, 0x14, 0x25, 0x59, 0x02]));
+
+        var cycleTime = ReadCycleTimeRequest.CreateNew(plc);
+        _ = cycleTime.BuildMessage(0x54);
+        var cycle = ReadCycleTimeResponse.ExtractCycleTime(cycleTime, CreateResponse(cycleTime, [0x00, 0x00, 0x01, 0x23, 0x00, 0x00, 0x04, 0x56, 0x00, 0x00, 0x00, 0x00]));
+
+        var cpuData = ReadCPUUnitDataRequest.CreateNew(plc);
+        _ = cpuData.BuildMessage(0x55);
+        var cpu = ReadCPUUnitDataResponse.ExtractData(CreateResponse(cpuData, BuildCpuUnitData("CS1G-CPU42H", "1.23")));
+
+        await Assert.That(Convert.ToHexString(ToBigEndianBytes(ReadMemoryAreaWordResponse.ExtractValues(readWords, wordResponse)))).IsEqualTo("1234FFFE");
+        await Assert.That(ToBitText(ReadMemoryAreaBitResponse.ExtractValues(readBits, bitResponse))).IsEqualTo("1,0,1");
+        await Assert.That(clock.ClockDateTime).IsEqualTo(new DateTime(2026, 6, 30, 14, 25, 59));
+        await Assert.That(clock.DayOfWeek).IsEqualTo((byte)2);
+        await Assert.That(cycle.AverageCycleTime).IsEqualTo(12.3d);
+        await Assert.That(cycle.MaximumCycleTime).IsEqualTo(45.6d);
+        await Assert.That(cycle.MinimumCycleTime).IsEqualTo(0d);
+        await Assert.That(cpu.ControllerModel).IsEqualTo("CS1G-CPU42H");
+        await Assert.That(cpu.ControllerVersion).IsEqualTo("1.23");
+    }
+
+    /// <summary>Verifies FINS response creation reports protocol mismatches and PLC response errors.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task FinsResponses_RejectInvalidFramesAndResponseCodes()
+    {
+        using var plc = CreateConnection();
+        var request = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 1, MemoryWordDataType.DataMemory);
+        _ = request.BuildMessage(0x61);
+
+        await Assert.That(CaptureException<FINSException>(() => FINSResponse.CreateNew(new byte[13], request)).Message).Contains("too short");
+        await Assert.That(CaptureException<FINSException>(() => FINSResponse.CreateNew(BuildResponseFrame(request, [], functionCode: 0xFF), request)).Message).Contains("Invalid Function Code");
+        await Assert.That(CaptureException<FINSException>(() => FINSResponse.CreateNew(BuildResponseFrame(request, [], subFunctionCode: 0xFF), request)).Message).Contains("Invalid Sub Function Code");
+        await Assert.That(CaptureException<FINSException>(() => FINSResponse.CreateNew(BuildResponseFrame(request, [], mainResponseCode: 0x82), request)).Message).Contains("Network Relay");
+        await Assert.That(CaptureException<FINSException>(() => FINSResponse.CreateNew(BuildResponseFrame(request, [], mainResponseCode: 0x02, subResponseCode: 0x05), request)).Message).Contains("Response Timeout");
+        await Assert.That(CaptureException<FINSException>(() => FINSResponse.CreateNew(BuildResponseFrame(request, [], serviceId: 0x62), request)).Message).Contains("Service ID");
+        await Assert.That(FINSResponse.ValidateFunctionCode(0x01)).IsTrue();
+        await Assert.That(FINSResponse.ValidateFunctionCode(0xFF)).IsFalse();
+        await Assert.That(FINSResponse.ValidateSubFunctionCode(0x01, 0x01)).IsTrue();
+        await Assert.That(FINSResponse.ValidateSubFunctionCode(0x01, 0xFF)).IsFalse();
+    }
+
+    /// <summary>Verifies response extractors validate short payloads and write acknowledgements validate null arguments.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ResponseExtractors_RejectShortPayloadsAndNullAcknowledgements()
+    {
+        using var plc = CreateConnection();
+        var readWords = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 2, MemoryWordDataType.DataMemory);
+        _ = readWords.BuildMessage(0x71);
+        var readBits = ReadMemoryAreaBitRequest.CreateNew(plc, 100, 0, 2, MemoryBitDataType.CommonIO);
+        _ = readBits.BuildMessage(0x72);
+        var readClock = ReadClockRequest.CreateNew(plc);
+        _ = readClock.BuildMessage(0x73);
+        var cycleTime = ReadCycleTimeRequest.CreateNew(plc);
+        _ = cycleTime.BuildMessage(0x74);
+        var cpuData = ReadCPUUnitDataRequest.CreateNew(plc);
+        _ = cpuData.BuildMessage(0x75);
+        var writeWords = WriteMemoryAreaWordRequest.CreateNew(plc, 100, MemoryWordDataType.DataMemory, [1]);
+        var writeBits = WriteMemoryAreaBitRequest.CreateNew(plc, 100, 0, MemoryBitDataType.CommonIO, [true]);
+        var writeClock = WriteClockRequest.CreateNew(plc, new DateTime(2026, 6, 30), 2);
+        var response = CreateResponse(writeWords, []);
+
+        await Assert.That(CaptureException<FINSException>(() => ReadMemoryAreaWordResponse.ExtractValues(readWords, CreateResponse(readWords, [1])))).IsNotNull();
+        await Assert.That(CaptureException<FINSException>(() => ReadMemoryAreaBitResponse.ExtractValues(readBits, CreateResponse(readBits, [1])))).IsNotNull();
+        await Assert.That(CaptureException<FINSException>(() => ReadClockResponse.ExtractClock(readClock, CreateResponse(readClock, [0x26])))).IsNotNull();
+        await Assert.That(CaptureException<FINSException>(() => ReadClockResponse.ExtractClock(readClock, CreateResponse(readClock, [0xA0, 0x01, 0x01, 0, 0, 0, 0])))).IsNotNull();
+        await Assert.That(CaptureException<FINSException>(() => ReadCycleTimeResponse.ExtractCycleTime(cycleTime, CreateResponse(cycleTime, [0])))).IsNotNull();
+        await Assert.That(CaptureException<FINSException>(() => ReadCPUUnitDataResponse.ExtractData(CreateResponse(cpuData, [0])))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => WriteMemoryAreaWordResponse.Validate(null!, response))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => WriteMemoryAreaWordResponse.Validate(writeWords, null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => WriteMemoryAreaBitResponse.Validate(null!, response))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => WriteMemoryAreaBitResponse.Validate(writeBits, null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => WriteClockResponse.Validate(null!, response))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => WriteClockResponse.Validate(writeClock, null!))).IsNotNull();
+    }
+
+    /// <summary>Verifies Host Link codec network framing and additional validation paths.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task HostLinkFinsFrameCodec_HandlesNetworkModeAndValidationFailures()
+    {
+        var options = new OmronSerialOptions("COM1") { FrameMode = OmronHostLinkFinsFrameMode.Network };
+        var codec = new HostLinkFinsFrameCodec(options);
+        var fins = Convert.FromHexString("800002000100000B00010101820064000002");
+        var body = "@00FA0" + Convert.ToHexString(fins);
+        var frame = body + HostLinkFinsFrameCodec.CalculateFcs(body) + "*\r";
+        var responseBody = "@00FA00" + Convert.ToHexString(fins);
+        var responseFrame = responseBody + HostLinkFinsFrameCodec.CalculateFcs(responseBody) + "*\r";
+
+        await Assert.That(codec.EncodeRequest(fins)).IsEqualTo(frame);
+        await Assert.That(Convert.ToHexString(codec.DecodeResponse(responseFrame).ToArray())).IsEqualTo(Convert.ToHexString(fins));
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateHostLinkCodec(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => HostLinkFinsFrameCodec.CalculateFcs(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentException>(() => codec.EncodeRequest(new byte[11]))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => codec.DecodeResponse(null!))).IsNotNull();
+        await Assert.That(CaptureException<OmronPLCException>(() => codec.DecodeResponse("@00FA0000"))).IsNotNull();
+        await Assert.That(CaptureException<OmronPLCException>(() => codec.DecodeResponse("@00FA0000*\r"))).IsNotNull();
+        await Assert.That(CaptureException<OmronPLCException>(() => codec.DecodeResponse("#00FA0000" + HostLinkFinsFrameCodec.CalculateFcs("#00FA0000") + "*\r")).Message).Contains("'@'");
+        await Assert.That(CaptureException<OmronPLCException>(() => codec.DecodeResponse("@01FA0000" + HostLinkFinsFrameCodec.CalculateFcs("@01FA0000") + "*\r")).Message).Contains("unit");
+        await Assert.That(CaptureException<OmronPLCException>(() => codec.DecodeResponse("@00FB0000" + HostLinkFinsFrameCodec.CalculateFcs("@00FB0000") + "*\r")).Message).Contains("header");
+
+        var directCodec = new HostLinkFinsFrameCodec(new OmronSerialOptions("COM1"));
+        const string ShortDirectBody = "@00FA00010203";
+        await Assert.That(CaptureException<OmronPLCException>(() => directCodec.DecodeResponse(ShortDirectBody + HostLinkFinsFrameCodec.CalculateFcs(ShortDirectBody) + "*\r")).Message).Contains("too short");
+    }
+
+    /// <summary>Verifies serial option and connection metadata validation paths.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task SerialOptionsAndConnectionMetadata_ValidateInputs()
+    {
+        await Assert.That(CaptureException<ArgumentException>(() => _ = CreateSerialOptions(" "))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { Protocol = (OmronSerialProtocol)255 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { HostLinkUnitNumber = 32 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { ResponseWaitTime = 16 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { BaudRate = 0 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { DataBits = 4 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { DataBits = 9 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => new OmronSerialOptions("COM1") { MaximumFrameLength = 0 }.Validate())).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => OmronPLCConnectionMetadata.ValidateNodeIdentifiers(0, 2, ConnectionMethod.UDP))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => OmronPLCConnectionMetadata.ValidateNodeIdentifiers(1, 0, ConnectionMethod.UDP))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => OmronPLCConnectionMetadata.ValidateNodeIdentifiers(1, 255, ConnectionMethod.UDP))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentException>(() => OmronPLCConnectionMetadata.ValidateNodeIdentifiers(1, 1, ConnectionMethod.UDP))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => OmronPLCConnectionMetadata.ValidateRemoteHost(null!))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentException>(() => OmronPLCConnectionMetadata.ValidateRemoteHost(string.Empty))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => OmronPLCConnectionMetadata.ValidatePort(ConnectionMethod.UDP, 0))).IsNotNull();
+        await Assert.That(OmronPLCConnectionMetadata.ValidateRemoteHost("127.0.0.1")).IsEqualTo("127.0.0.1");
+        OmronPLCConnectionMetadata.ValidatePort(ConnectionMethod.Serial, 0);
+        await Assert.That(OmronPLCConnectionMetadata.GetPLCType("CS1G-CPU42H")).IsEqualTo(PLCType.C_Series);
+        await Assert.That(OmronPLCConnectionMetadata.GetPLCType("NJ501-1300")).IsEqualTo(PLCType.NJ501);
+        await Assert.That(OmronPLCConnectionMetadata.GetPLCType("NY532-5400")).IsEqualTo(PLCType.NJ_NX_NY_Series);
+        await Assert.That(OmronPLCConnectionMetadata.GetPLCType("UNKNOWN")).IsEqualTo(PLCType.Unknown);
+    }
+
+    /// <summary>Verifies serial Toolbus frame-buffer helpers trim noise and find sync frames.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task SerialToolbusFrameBuffer_TrimsNoiseAndFindsSynchronizationFrames()
+    {
+        var noisy = new List<byte> { 0x00, 0x01, 0xAB, 0x02 };
+        SerialToolbusFrameBuffer.TrimBeforeFrameStart(noisy);
+
+        var noFrame = new List<byte> { 0x00, 0x01 };
+        SerialToolbusFrameBuffer.TrimBeforeFrameStart(noFrame);
+
+        var aligned = new List<byte> { 0xAB, 0x02 };
+        SerialToolbusFrameBuffer.TrimBeforeFrameStart(aligned);
+
+        await Assert.That(Convert.ToHexString(noisy.ToArray())).IsEqualTo("AB02");
+        await Assert.That(noFrame.Count).IsEqualTo(0);
+        await Assert.That(Convert.ToHexString(aligned.ToArray())).IsEqualTo("AB02");
+        await Assert.That(SerialToolbusFrameBuffer.ContainsSynchronizationFrame([0x00, 0xAC, 0x01], [0xAC, 0x01])).IsTrue();
+        await Assert.That(SerialToolbusFrameBuffer.ContainsSynchronizationFrame([0x00, 0xAC, 0x02], [0xAC, 0x01])).IsFalse();
+    }
+
+    /// <summary>Verifies simple value objects expose their initialized values.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ValueObjects_ExposeConstructorValues()
+    {
+        var bcd16 = new Bcd16(1234);
+        var bcd32 = new Bcd32(12_345_678);
+        var bcdU16 = new BcdU16(9876);
+        var bcdU32 = new BcdU32(87_654_321);
+        var tag = new PlcTag<int>("Speed", "D100") { Value = 42 };
+        var expectedClock = new DateTime(2026, 6, 30);
+        var attribute = new PlcTagAttribute("D100")
+        {
+            TagName = "Speed",
+            Register = false,
+            Observe = false,
+            Writable = true,
+        };
+        var finsInner = new InvalidOperationException("inner");
+        var plcInner = new InvalidOperationException("inner");
+        var readBits = new ReadBitsResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d, Values = [true] };
+        var readWords = new ReadWordsResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d, Values = [123] };
+        var readClock = new ReadClockResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d, Clock = expectedClock, DayOfWeek = 2 };
+        var readCycleTime = new ReadCycleTimeResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d, MinimumCycleTime = 1.2d, MaximumCycleTime = 3.4d, AverageCycleTime = 2.3d };
+        var writeBits = new WriteBitsResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d };
+        var writeWords = new WriteWordsResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d };
+        var writeClock = new WriteClockResult { BytesSent = 1, PacketsSent = 2, BytesReceived = 3, PacketsReceived = 4, Duration = 5.5d };
+
+        await Assert.That(bcd16.Value).IsEqualTo((short)1234);
+        await Assert.That(bcd16.ToString()).IsEqualTo("1234");
+        await Assert.That(bcd16.GetHashCode()).IsEqualTo(((short)1234).GetHashCode());
+        await Assert.That(bcd32.Value).IsEqualTo(12_345_678);
+        await Assert.That(bcd32.ToString()).IsEqualTo("12345678");
+        await Assert.That(bcd32.GetHashCode()).IsEqualTo(12_345_678.GetHashCode());
+        await Assert.That(bcdU16.Value).IsEqualTo((ushort)9876);
+        await Assert.That(bcdU16.ToString()).IsEqualTo("9876");
+        await Assert.That(bcdU16.GetHashCode()).IsEqualTo(((ushort)9876).GetHashCode());
+        await Assert.That(bcdU32.Value).IsEqualTo(87_654_321u);
+        await Assert.That(bcdU32.ToString()).IsEqualTo("87654321");
+        await Assert.That(bcdU32.GetHashCode()).IsEqualTo(87_654_321u.GetHashCode());
+        await Assert.That(tag.TagName).IsEqualTo("Speed");
+        await Assert.That(tag.Address).IsEqualTo("D100");
+        await Assert.That(tag.TagType).IsEqualTo(typeof(int));
+        await Assert.That(tag.Value).IsEqualTo(42);
+        await Assert.That(((IPlcTag)tag).Value).IsEqualTo(42);
+        await Assert.That(attribute.Address).IsEqualTo("D100");
+        await Assert.That(attribute.TagName).IsEqualTo("Speed");
+        await Assert.That(attribute.Register).IsFalse();
+        await Assert.That(attribute.Observe).IsFalse();
+        await Assert.That(attribute.Writable).IsTrue();
+        await Assert.That(new PlcTagAttribute("D101").Register).IsTrue();
+        await Assert.That(new PlcTagAttribute("D101").Observe).IsTrue();
+        await Assert.That(new FINSException().Message).IsEqualTo("Exception of type 'OmronPlcRx.FINSException' was thrown.");
+        await Assert.That(new FINSException("fins").Message).IsEqualTo("fins");
+        await Assert.That(new FINSException("fins", finsInner).InnerException).IsEqualTo(finsInner);
+        await Assert.That(new OmronPLCException().Message).IsEqualTo("Exception of type 'OmronPlcRx.OmronPLCException' was thrown.");
+        await Assert.That(new OmronPLCException("plc").Message).IsEqualTo("plc");
+        await Assert.That(new OmronPLCException("plc", plcInner).InnerException).IsEqualTo(plcInner);
+        await Assert.That(readBits.BytesSent + readBits.PacketsSent + readBits.BytesReceived + readBits.PacketsReceived).IsEqualTo(10);
+        await Assert.That(readBits.Duration).IsEqualTo(5.5d);
+        await Assert.That(readBits.Values[0]).IsTrue();
+        await Assert.That(readWords.Values[0]).IsEqualTo((short)123);
+        await Assert.That(readClock.Clock).IsEqualTo(expectedClock);
+        await Assert.That(readClock.DayOfWeek).IsEqualTo(2);
+        await Assert.That(readCycleTime.MinimumCycleTime).IsEqualTo(1.2d);
+        await Assert.That(readCycleTime.MaximumCycleTime).IsEqualTo(3.4d);
+        await Assert.That(readCycleTime.AverageCycleTime).IsEqualTo(2.3d);
+        await Assert.That(writeBits.Duration + writeWords.Duration + writeClock.Duration).IsEqualTo(16.5d);
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateTag<int>(null!, "D100"))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateTag<int>("Speed", null!))).IsNotNull();
+    }
+
+    /// <summary>Verifies base channel processing maps a valid request attempt to metrics and response data.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task BaseChannel_ProcessRequestReturnsMetricsAndParsedResponse()
+    {
+        using var plc = CreateConnection();
+        using var channel = new TestChannel { ResponseData = [0x12, 0x34] };
+        var request = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 1, MemoryWordDataType.DataMemory);
+
+        var result = await channel.ProcessRequestAsync(request, 100, 0, CancellationToken.None);
+
+        await Assert.That(result.BytesSent).IsEqualTo(18);
+        await Assert.That(result.PacketsSent).IsEqualTo(1);
+        await Assert.That(result.BytesReceived).IsEqualTo(16);
+        await Assert.That(result.PacketsReceived).IsEqualTo(1);
+        await Assert.That(result.Duration >= 0).IsTrue();
+        await Assert.That(result.Response.ServiceID).IsEqualTo((byte)1);
+        await Assert.That(Convert.ToHexString(result.Response.Data!)).IsEqualTo("1234");
+        await Assert.That(channel.SendCount).IsEqualTo(1);
+        await Assert.That(channel.ReceiveCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies base channel processing reinitializes the client before retry attempts.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task BaseChannel_ProcessRequestRetriesAfterTransientSendFailure()
+    {
+        using var plc = CreateConnection();
+        using var channel = new TestChannel { ResponseData = [0x12, 0x34], FailFirstSend = true };
+        var request = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 1, MemoryWordDataType.DataMemory);
+
+        var result = await channel.ProcessRequestAsync(request, 100, 1, CancellationToken.None);
+
+        await Assert.That(Convert.ToHexString(result.Response.Data!)).IsEqualTo("1234");
+        await Assert.That(channel.SendCount).IsEqualTo(2);
+        await Assert.That(channel.DestroyCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies base channel processing purges stale responses when service identifiers mismatch.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task BaseChannel_ProcessRequestPurgesServiceIdMismatches()
+    {
+        using var plc = CreateConnection();
+        using var channel = new TestChannel { ResponseData = [0x12, 0x34], ForceServiceIdMismatch = true, ThrowDuringPurge = true };
+        var request = ReadMemoryAreaWordRequest.CreateNew(plc, 100, 1, MemoryWordDataType.DataMemory);
+
+        var ex = await CaptureExceptionAsync<OmronPLCException>(() => channel.ProcessRequestAsync(request, 100, 0, CancellationToken.None));
+
+        await Assert.That(ex.Message).Contains("FINS Error Response");
+        await Assert.That(channel.PurgeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies TCP client loopback send, receive, properties and endpoint helpers.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task TcpClient_ConnectsSendsReceivesAndExposesSocketState()
+    {
+        var listener = new NetTcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = EchoTcpAsync(listener);
+            using var client = new CoreTcpClient("127.0.0.1", port);
+
+            client.NoDelay = true;
+            client.LingerState = new(true, 0);
+            client.KeepAliveEnabled = true;
+            await client.ConnectAsync(1000, CancellationToken.None);
+            var bytesSent = await client.SendAsync([1, 2, 3], 1000, CancellationToken.None);
+            var receiveBuffer = new byte[2];
+            var bytesReceived = await client.ReceiveAsync(receiveBuffer, 1000, CancellationToken.None);
+            var serverReceived = await serverTask.ConfigureAwait(false);
+            var dnsEndpoint = new System.Net.DnsEndPoint("localhost", 9600);
+
+            await Assert.That(bytesSent).IsEqualTo(3);
+            await Assert.That(bytesReceived).IsEqualTo(2);
+            await Assert.That(Convert.ToHexString(receiveBuffer)).IsEqualTo("0405");
+            await Assert.That(serverReceived).IsEqualTo(3);
+            await Assert.That(client.Connected).IsTrue();
+            await Assert.That(client.Socket).IsNotNull();
+            await Assert.That(client.NoDelay).IsTrue();
+            await Assert.That(client.LingerState!.Enabled).IsTrue();
+            await Assert.That(client.KeepAliveEnabled).IsTrue();
+            await Assert.That(TcpSocketConfiguration.GetRemoteHostAndPort(dnsEndpoint)).IsEqualTo(("localhost", 9600));
+            await Assert.That(TcpSocketConfiguration.GetRemoteHostAndPort(null)).IsEqualTo((string.Empty, 0));
+
+            client.Dispose();
+
+            await Assert.That(client.Connected).IsFalse();
+            await Assert.That(client.Socket).IsNull();
+            await Assert.That(client.NoDelay).IsFalse();
+            await Assert.That(client.LingerState).IsNull();
+            await Assert.That(client.KeepAliveEnabled).IsFalse();
+            var disposedConnect = await CaptureExceptionAsync<ObjectDisposedException>(() => client.ConnectAsync(1, CancellationToken.None));
+            await Assert.That(disposedConnect).IsNotNull();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    /// <summary>Verifies UDP client loopback send, receive, properties and disposed guards.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task UdpClient_SendsReceivesAndExposesSocketState()
+    {
+        using var server = new NetUdpClient(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 0));
+        var endpoint = (System.Net.IPEndPoint)server.Client.LocalEndPoint!;
+        var serverTask = EchoUdpAsync(server);
+        using var client = new CoreUdpClient(System.Net.IPAddress.Loopback, endpoint.Port);
+
+        var bytesSent = await client.SendAsync([1, 2, 3], 1000, CancellationToken.None);
+        var receiveBuffer = new byte[2];
+        var bytesReceived = await client.ReceiveAsync(receiveBuffer, 1000, CancellationToken.None);
+        var serverReceived = await serverTask.ConfigureAwait(false);
+
+        await Assert.That(bytesSent).IsEqualTo(3);
+        await Assert.That(bytesReceived).IsEqualTo(2);
+        await Assert.That(Convert.ToHexString(receiveBuffer)).IsEqualTo("0708");
+        await Assert.That(serverReceived).IsEqualTo(3);
+        await Assert.That(client.Socket).IsNotNull();
+
+        client.Dispose();
+
+        await Assert.That(client.Available).IsEqualTo(0);
+        await Assert.That(client.Socket).IsNull();
+        var disposedSend = await CaptureExceptionAsync<ObjectDisposedException>(() => client.SendAsync([1], 1, CancellationToken.None));
+        await Assert.That(disposedSend).IsNotNull();
+    }
+
+    /// <summary>Verifies socket wrapper constructors validate their inputs.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task SocketClients_ValidateConstructorInputs()
+    {
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateTcpClient((string)null!, 9600))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => _ = CreateTcpClient("127.0.0.1", -1))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateTcpClient((System.Net.IPAddress)null!, 9600))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => _ = CreateTcpClient(System.Net.IPAddress.Loopback, 65_536))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateUdpClient((string)null!, 9600))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => _ = CreateUdpClient("127.0.0.1", -1))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentNullException>(() => _ = CreateUdpClient((System.Net.IPAddress)null!, 9600))).IsNotNull();
+        await Assert.That(CaptureException<ArgumentOutOfRangeException>(() => _ = CreateUdpClient(System.Net.IPAddress.Loopback, 65_536))).IsNotNull();
+    }
+
+    /// <summary>Verifies socket cleanup helpers observe canceled work without surfacing expected cancellation exceptions.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task SocketOperationCleanup_ObservesCancellationExceptions()
+    {
+        using var delayCts = new CancellationTokenSource();
+        var delayTask = Task.Delay(TimeSpan.FromMinutes(1), delayCts.Token);
+
+        await SocketOperationCleanup.CancelDelayAsync(delayCts, delayTask);
+
+        using var operationCts = new CancellationTokenSource();
+        var operationTask = Task.Delay(TimeSpan.FromMinutes(1), operationCts.Token);
+
+        await SocketOperationCleanup.CancelSocketOperationAsync(operationCts, operationTask);
+    }
+
+    /// <summary>Verifies injected PLC connections initialize by reading controller information.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task OmronPlcConnection_InitializeReadsControllerInformation()
+    {
+        using var channel = new TestChannel { ResponseData = BuildCpuUnitData("CS1G-CPU42H", "1.23") };
+        using var plc = CreateInjectedConnection(channel, isInitialized: false);
+
+        await plc.InitializeAsync(CancellationToken.None);
+
+        await Assert.That(plc.IsInitialized).IsTrue();
+        await Assert.That(plc.ControllerModel).IsEqualTo("CS1G-CPU42H");
+        await Assert.That(plc.ControllerVersion).IsEqualTo("1.23");
+        await Assert.That(plc.PLCType).IsEqualTo(PLCType.C_Series);
+        await Assert.That(channel.InitializeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies injected PLC connections execute read and write operations through the channel.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task OmronPlcConnection_ReadsAndWritesThroughInjectedChannel()
+    {
+        using var readWordsChannel = new TestChannel { ResponseData = [0x12, 0x34, 0xFF, 0xFE] };
+        using var readWordsPlc = CreateInjectedConnection(readWordsChannel);
+        var words = await readWordsPlc.ReadWordsAsync(100, 2, MemoryWordDataType.DataMemory, CancellationToken.None);
+
+        using var readBitsChannel = new TestChannel { ResponseData = [1, 0] };
+        using var readBitsPlc = CreateInjectedConnection(readBitsChannel);
+        var bits = await readBitsPlc.ReadBitsAsync(100, 0, 2, MemoryBitDataType.CommonIO, CancellationToken.None);
+
+        using var clockChannel = new TestChannel { ResponseData = [0x26, 0x06, 0x30, 0x14, 0x25, 0x59, 0x02] };
+        using var clockPlc = CreateInjectedConnection(clockChannel);
+        var clock = await clockPlc.ReadClockAsync(CancellationToken.None);
+
+        using var cycleChannel = new TestChannel { ResponseData = [0x00, 0x00, 0x01, 0x23, 0x00, 0x00, 0x04, 0x56, 0x00, 0x00, 0x00, 0x00] };
+        using var cyclePlc = CreateInjectedConnection(cycleChannel);
+        var cycle = await cyclePlc.ReadCycleTimeAsync(CancellationToken.None);
+
+        using var writeWordsChannel = new TestChannel();
+        using var writeWordsPlc = CreateInjectedConnection(writeWordsChannel);
+        var writeWords = await writeWordsPlc.WriteWordsAsync([1, 2], 100, MemoryWordDataType.DataMemory, CancellationToken.None);
+
+        using var writeBitsChannel = new TestChannel();
+        using var writeBitsPlc = CreateInjectedConnection(writeBitsChannel);
+        var writeBits = await writeBitsPlc.WriteBitsAsync([true, false], 100, 0, MemoryBitDataType.CommonIO, CancellationToken.None);
+
+        using var writeClockChannel = new TestChannel();
+        using var writeClockPlc = CreateInjectedConnection(writeClockChannel);
+        var writeClock = await writeClockPlc.WriteClockAsync(new(2026, 6, 30, 14, 25, 59), 2, CancellationToken.None);
+
+        await Assert.That(Convert.ToHexString(ToBigEndianBytes(words.Values))).IsEqualTo("1234FFFE");
+        await Assert.That(ToBitText(bits.Values)).IsEqualTo("1,0");
+        await Assert.That(clock.Clock).IsEqualTo(new DateTime(2026, 6, 30, 14, 25, 59));
+        await Assert.That(clock.DayOfWeek).IsEqualTo(2);
+        await Assert.That(cycle.AverageCycleTime).IsEqualTo(12.3d);
+        await Assert.That(cycle.MaximumCycleTime).IsEqualTo(45.6d);
+        await Assert.That(cycle.MinimumCycleTime).IsEqualTo(0d);
+        await Assert.That(writeWords.BytesSent > 0).IsTrue();
+        await Assert.That(writeBits.BytesSent > 0).IsTrue();
+        await Assert.That(writeClock.BytesSent > 0).IsTrue();
+    }
+
+    /// <summary>Verifies PLC connection validation rejects invalid operation inputs.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task OmronPlcConnection_RejectsInvalidOperationInputs()
+    {
+        using var channel = new TestChannel();
+        using var plc = CreateInjectedConnection(channel);
+        using var uninitialized = CreateInjectedConnection(new TestChannel(), isInitialized: false);
+        using var seriesPlc = CreateInjectedConnection(new TestChannel(), plcType: PLCType.NX102);
+
+        await AssertThrowsAsync<OmronPLCException>(() => uninitialized.ReadWordsAsync(100, 1, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadBitsAsync(100, 16, 1, MemoryBitDataType.CommonIO, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadBitsAsync(100, 0, 0, MemoryBitDataType.CommonIO, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadBitsAsync(100, 15, 2, MemoryBitDataType.CommonIO, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentException>(() => plc.ReadBitsAsync(100, 0, 1, MemoryBitDataType.None, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadBitsAsync(32_768, 0, 1, MemoryBitDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadWordsAsync(100, 0, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadWordsAsync(100, 1000, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentException>(() => plc.ReadWordsAsync(100, 1, MemoryWordDataType.None, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.ReadWordsAsync(32_768, 1, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentNullException>(() => plc.WriteBitsAsync(null!, 100, 0, MemoryBitDataType.CommonIO, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteBitsAsync([], 100, 0, MemoryBitDataType.CommonIO, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteBitsAsync([true, false], 100, 15, MemoryBitDataType.CommonIO, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentNullException>(() => plc.WriteWordsAsync(null!, 100, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteWordsAsync([], 100, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteWordsAsync(new short[997], 100, MemoryWordDataType.DataMemory, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteClockAsync(new(1997, 12, 31), CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteClockAsync(new(2070, 1, 1), CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteClockAsync(new(2026, 6, 30), -1, CancellationToken.None));
+        await AssertThrowsAsync<ArgumentOutOfRangeException>(() => plc.WriteClockAsync(new(2026, 6, 30), 7, CancellationToken.None));
+        await AssertThrowsAsync<OmronPLCException>(() => seriesPlc.ReadCycleTimeAsync(CancellationToken.None));
+    }
+
+    /// <summary>Creates a connection instance without opening a channel.</summary>
+    /// <returns>The connection instance.</returns>
+    private static OmronPLCConnection CreateConnection() => new(1, 2, ConnectionMethod.UDP, "127.0.0.1", retries: 0);
+
+    /// <summary>Creates an injected PLC connection for unit tests.</summary>
+    /// <param name="channel">The test channel.</param>
+    /// <param name="plcType">The PLC type.</param>
+    /// <param name="isInitialized">A value indicating whether the connection starts initialized.</param>
+    /// <returns>The injected connection.</returns>
+    private static OmronPLCConnection CreateInjectedConnection(TestChannel channel, PLCType plcType = PLCType.CJ2, bool isInitialized = true) =>
+        new(1, 2, ConnectionMethod.UDP, "127.0.0.1", channel, timeout: 100, retries: 0, plcType: plcType, controllerModel: "CJ2M", controllerVersion: "1.0", isInitialized: isInitialized);
+
+    /// <summary>Creates a TCP client for constructor validation tests.</summary>
+    /// <param name="host">The remote host.</param>
+    /// <param name="port">The remote port.</param>
+    /// <returns>The TCP client.</returns>
+    private static CoreTcpClient CreateTcpClient(string host, int port) => new(host, port);
+
+    /// <summary>Creates a TCP client for constructor validation tests.</summary>
+    /// <param name="address">The remote address.</param>
+    /// <param name="port">The remote port.</param>
+    /// <returns>The TCP client.</returns>
+    private static CoreTcpClient CreateTcpClient(System.Net.IPAddress address, int port) => new(address, port);
+
+    /// <summary>Creates a UDP client for constructor validation tests.</summary>
+    /// <param name="host">The remote host.</param>
+    /// <param name="port">The remote port.</param>
+    /// <returns>The UDP client.</returns>
+    private static CoreUdpClient CreateUdpClient(string host, int port) => new(host, port);
+
+    /// <summary>Creates a UDP client for constructor validation tests.</summary>
+    /// <param name="address">The remote address.</param>
+    /// <param name="port">The remote port.</param>
+    /// <returns>The UDP client.</returns>
+    private static CoreUdpClient CreateUdpClient(System.Net.IPAddress address, int port) => new(address, port);
+
+    /// <summary>Echoes a TCP message using the core TCP socket wrapper.</summary>
+    /// <param name="listener">The TCP listener.</param>
+    /// <returns>The number of bytes received from the client.</returns>
+    private static async Task<int> EchoTcpAsync(NetTcpListener listener)
+    {
+        using var acceptedSocket = await listener.AcceptSocketAsync().ConfigureAwait(false);
+        using var server = new CoreTcpClient(acceptedSocket);
+        var receiveBuffer = new byte[3];
+        var received = await server.ReceiveAsync(receiveBuffer, 1000, CancellationToken.None).ConfigureAwait(false);
+        _ = await server.SendAsync([4, 5], 1000, CancellationToken.None).ConfigureAwait(false);
+        return received;
+    }
+
+    /// <summary>Echoes a UDP message using the framework UDP server.</summary>
+    /// <param name="server">The UDP server.</param>
+    /// <returns>The number of bytes received from the client.</returns>
+    private static async Task<int> EchoUdpAsync(NetUdpClient server)
+    {
+        var result = await server.ReceiveAsync(CancellationToken.None).ConfigureAwait(false);
+        var response = new byte[] { 7, 8 };
+        _ = await server.SendAsync(response, response.Length, result.RemoteEndPoint).ConfigureAwait(false);
+        return result.Buffer.Length;
+    }
+
+    /// <summary>Creates Host Link codec instances for constructor validation tests.</summary>
+    /// <param name="options">The serial options.</param>
+    /// <returns>The codec.</returns>
+    private static HostLinkFinsFrameCodec CreateHostLinkCodec(OmronSerialOptions options) => new(options);
+
+    /// <summary>Creates serial options for constructor validation tests.</summary>
+    /// <param name="portName">The port name.</param>
+    /// <returns>The serial options.</returns>
+    private static OmronSerialOptions CreateSerialOptions(string portName) => new(portName);
+
+    /// <summary>Creates a PLC tag for constructor validation tests.</summary>
+    /// <typeparam name="T">The tag value type.</typeparam>
+    /// <param name="tagName">The tag name.</param>
+    /// <param name="address">The tag address.</param>
+    /// <returns>The tag.</returns>
+    private static PlcTag<T> CreateTag<T>(string tagName, string address) => new(tagName, address);
+
+    /// <summary>Creates a successful FINS response for a request.</summary>
+    /// <param name="request">The request.</param>
+    /// <param name="data">The response data.</param>
+    /// <returns>The parsed response.</returns>
+    private static FINSResponse CreateResponse(FINSRequest request, byte[] data) => FINSResponse.CreateNew(BuildResponseFrame(request, data), request);
+
+    /// <summary>Builds a raw FINS response frame.</summary>
+    /// <param name="request">The request.</param>
+    /// <param name="data">The response data.</param>
+    /// <param name="serviceId">The optional service id.</param>
+    /// <param name="functionCode">The optional function code.</param>
+    /// <param name="subFunctionCode">The optional sub-function code.</param>
+    /// <param name="mainResponseCode">The main response code.</param>
+    /// <param name="subResponseCode">The sub response code.</param>
+    /// <returns>The raw frame.</returns>
+    private static byte[] BuildResponseFrame(
+        FINSRequest request,
+        byte[] data,
+        byte? serviceId = null,
+        byte? functionCode = null,
+        byte? subFunctionCode = null,
+        byte mainResponseCode = 0,
+        byte subResponseCode = 0)
+    {
+        var message = new byte[FINSResponse.HeaderLength + FINSResponse.CommandLength + FINSResponse.ResponseCodeLength + data.Length];
+        message[9] = serviceId ?? request.ServiceID;
+        message[10] = functionCode ?? request.FunctionCode;
+        message[11] = subFunctionCode ?? request.SubFunctionCode;
+        message[12] = mainResponseCode;
+        message[13] = subResponseCode;
+        Array.Copy(data, 0, message, FINSResponse.HeaderLength + FINSResponse.CommandLength + FINSResponse.ResponseCodeLength, data.Length);
+        return message;
+    }
+
+    /// <summary>Builds CPU unit data with fixed controller model and version fields.</summary>
+    /// <param name="model">The controller model.</param>
+    /// <param name="version">The controller version.</param>
+    /// <returns>The response payload.</returns>
+    private static byte[] BuildCpuUnitData(string model, string version)
+    {
+        var data = new byte[ReadCPUUnitDataResponse.TotalResponseLength];
+        CopyAscii(model, data, 0, ReadCPUUnitDataResponse.ControllerModelLength);
+        CopyAscii(version, data, ReadCPUUnitDataResponse.ControllerModelLength, ReadCPUUnitDataResponse.ControllerVersionLength);
+        return data;
+    }
+
+    /// <summary>Copies ASCII text to a fixed-width field.</summary>
+    /// <param name="text">The text.</param>
+    /// <param name="buffer">The destination buffer.</param>
+    /// <param name="offset">The destination offset.</param>
+    /// <param name="length">The maximum field length.</param>
+    private static void CopyAscii(string text, byte[] buffer, int offset, int length)
+    {
+        var bytes = System.Text.Encoding.ASCII.GetBytes(text);
+        Array.Copy(bytes, 0, buffer, offset, Math.Min(bytes.Length, length));
+    }
+
+    /// <summary>Converts PLC words to big-endian protocol bytes.</summary>
+    /// <param name="words">The PLC words.</param>
+    /// <returns>The protocol bytes.</returns>
+    private static byte[] ToBigEndianBytes(short[] words)
+    {
+        var bytes = new byte[words.Length * 2];
+        for (var i = 0; i < words.Length; i++)
+        {
+            var word = (ushort)words[i];
+            bytes[i * 2] = (byte)(word >> 8);
+            bytes[(i * 2) + 1] = (byte)(word & 0xFF);
+        }
+
+        return bytes;
+    }
+
+    /// <summary>Converts bit values to compact assertion text.</summary>
+    /// <param name="values">The bit values.</param>
+    /// <returns>The bit text.</returns>
+    private static string ToBitText(bool[] values)
+    {
+        var text = new System.Text.StringBuilder(values.Length + Math.Max(0, values.Length - 1));
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                _ = text.Append(',');
+            }
+
+            _ = text.Append(values[i] ? '1' : '0');
+        }
+
+        return text.ToString();
+    }
+
+    /// <summary>Converts a memory value to uppercase hexadecimal.</summary>
+    /// <param name="memory">The memory value.</param>
+    /// <returns>The hexadecimal text.</returns>
+    private static string ToHex(ReadOnlyMemory<byte> memory) => Convert.ToHexString(memory.ToArray());
+
+    /// <summary>Captures an expected exception from an action.</summary>
+    /// <typeparam name="TException">The expected exception type.</typeparam>
+    /// <param name="action">The action to invoke.</param>
+    /// <returns>The captured exception.</returns>
+    private static TException CaptureException<TException>(Action action)
+        where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException($"Expected exception of type {nameof(TException)}.");
+    }
+
+    /// <summary>Captures an expected exception from an asynchronous action.</summary>
+    /// <typeparam name="TException">The expected exception type.</typeparam>
+    /// <param name="action">The action to invoke.</param>
+    /// <returns>The captured exception.</returns>
+    private static async Task<TException> CaptureExceptionAsync<TException>(Func<Task> action)
+        where TException : Exception
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException($"Expected exception of type {nameof(TException)}.");
+    }
+
+    /// <summary>Asserts that an asynchronous action throws the expected exception type.</summary>
+    /// <typeparam name="TException">The expected exception type.</typeparam>
+    /// <param name="action">The action to invoke.</param>
+    /// <returns>A task that represents the asynchronous assertion.</returns>
+    private static async Task AssertThrowsAsync<TException>(Func<Task> action)
+        where TException : Exception
+    {
+        var ex = await CaptureExceptionAsync<TException>(action).ConfigureAwait(false);
+        await Assert.That(ex).IsNotNull();
+    }
+
+    /// <summary>Fake channel used to exercise base-channel orchestration without sockets.</summary>
+    private sealed class TestChannel : BaseChannel
+    {
+        /// <summary>Stores the last sent request message.</summary>
+        private byte[] _lastSent = [];
+
+        /// <summary>Initializes a new instance of the <see cref="TestChannel"/> class.</summary>
+        public TestChannel()
+            : base("test", 9600)
+        {
+        }
+
+        /// <summary>Gets or sets the response data to emit.</summary>
+        public byte[] ResponseData { get; set; } = [];
+
+        /// <summary>Gets or sets a value indicating whether the first send should fail.</summary>
+        public bool FailFirstSend { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether the response service id should mismatch.</summary>
+        public bool ForceServiceIdMismatch { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether purge should throw.</summary>
+        public bool ThrowDuringPurge { get; set; }
+
+        /// <summary>Gets the initialize call count.</summary>
+        public int InitializeCount { get; private set; }
+
+        /// <summary>Gets the destroy call count.</summary>
+        public int DestroyCount { get; private set; }
+
+        /// <summary>Gets the send call count.</summary>
+        public int SendCount { get; private set; }
+
+        /// <summary>Gets the receive call count.</summary>
+        public int ReceiveCount { get; private set; }
+
+        /// <summary>Gets the purge call count.</summary>
+        public int PurgeCount { get; private set; }
+
+        /// <inheritdoc />
+        internal override Task InitializeAsync(int timeout, CancellationToken cancellationToken)
+        {
+            InitializeCount++;
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        protected override Task DestroyAndInitializeClient(int timeout, CancellationToken cancellationToken)
+        {
+            DestroyCount++;
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        protected override Task<SendMessageResult> SendMessageAsync(ReadOnlyMemory<byte> message, int timeout, CancellationToken cancellationToken)
+        {
+            SendCount++;
+            if (FailFirstSend && SendCount == 1)
+            {
+                throw new TimeoutException("first send failed");
+            }
+
+            _lastSent = message.ToArray();
+            return Task.FromResult(new SendMessageResult
+            {
+                Bytes = _lastSent.Length,
+                Packets = 1,
+            });
+        }
+
+        /// <inheritdoc />
+        protected override Task<ReceiveMessageResult> ReceiveMessageAsync(int timeout, CancellationToken cancellationToken)
+        {
+            ReceiveCount++;
+            var response = BuildResponseFromLastSent();
+            return Task.FromResult(new ReceiveMessageResult
+            {
+                Bytes = response.Length,
+                Packets = 1,
+                Message = response,
+            });
+        }
+
+        /// <inheritdoc />
+        protected override Task PurgeReceiveBuffer(int timeout, CancellationToken cancellationToken)
+        {
+            PurgeCount++;
+            return ThrowDuringPurge ? throw new TimeoutException("purge failed") : Task.CompletedTask;
+        }
+
+        /// <summary>Builds a response frame from the last request message.</summary>
+        /// <returns>The response frame.</returns>
+        private byte[] BuildResponseFromLastSent()
+        {
+            var response = new byte[FINSResponse.HeaderLength + FINSResponse.CommandLength + FINSResponse.ResponseCodeLength + ResponseData.Length];
+            response[9] = (byte)(ForceServiceIdMismatch ? _lastSent[9] + 1 : _lastSent[9]);
+            response[10] = _lastSent[10];
+            response[11] = _lastSent[11];
+            Array.Copy(ResponseData, 0, response, FINSResponse.HeaderLength + FINSResponse.CommandLength + FINSResponse.ResponseCodeLength, ResponseData.Length);
+            return response;
+        }
+    }
+}

--- a/tests/OmronPlcRx.Tests/OmronPlcRx.Tests.csproj
+++ b/tests/OmronPlcRx.Tests/OmronPlcRx.Tests.csproj
@@ -11,11 +11,13 @@
   <ItemGroup>
     <PackageReference Include="ReactiveUI.Primitives" Version="5.8.0" ExcludeAssets="analyzers" />
     <PackageReference Include="ReactiveUI.Primitives.Async" Version="5.8.0" ExcludeAssets="analyzers" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" PrivateAssets="all" />
     <PackageReference Include="TUnit" Version="1.57.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OmronPlcRx\OmronPlcRx.csproj" />
+    <ProjectReference Include="..\..\src\OmronPlcRx.Reactive\OmronPlcRx.Reactive.csproj" />
     <ProjectReference Include="..\..\src\OmronPlcRx.SourceGenerators\OmronPlcRx.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/OmronPlcRx.Tests/ReactiveFakeOmronPlcRx.cs
+++ b/tests/OmronPlcRx.Tests/ReactiveFakeOmronPlcRx.cs
@@ -1,0 +1,171 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
+using ReactiveIOmronPlcRx = global::OmronPlcRx.Reactive.IOmronPlcRx;
+using ReactiveIPlcTag = global::OmronPlcRx.Reactive.Tags.IPlcTag;
+using ReactiveOmronPLCException = global::OmronPlcRx.Reactive.OmronPLCException;
+using ReactivePLCType = global::OmronPlcRx.Reactive.Enums.PLCType;
+using ReactiveReadClockResult = global::OmronPlcRx.Reactive.Results.ReadClockResult;
+using ReactiveReadCycleTimeResult = global::OmronPlcRx.Reactive.Results.ReadCycleTimeResult;
+using ReactiveWriteClockResult = global::OmronPlcRx.Reactive.Results.WriteClockResult;
+
+namespace OmronPlcRx.Reactive.Tests;
+
+/// <summary>In-memory reactive PLC test double used by generated stream tests.</summary>
+internal sealed class ReactiveFakeOmronPlcRx : ReactiveIOmronPlcRx
+{
+    /// <summary>Publishes PLC errors.</summary>
+    private readonly Signal<ReactiveOmronPLCException?> _errors = new();
+
+    /// <summary>Stores per-tag value subjects.</summary>
+    private readonly Dictionary<string, BehaviorSignal<object?>> _subjects = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Stores the latest per-tag values.</summary>
+    private readonly Dictionary<string, object?> _values = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Publishes aggregate tag change notifications.</summary>
+    private readonly Signal<ReactiveIPlcTag?> _all = new();
+
+    /// <summary>Gets the tag registrations captured by this fake PLC.</summary>
+    public List<Registration> Registrations { get; } = [];
+
+    /// <summary>Gets the writes captured by this fake PLC.</summary>
+    public List<Write> Writes { get; } = [];
+
+    /// <inheritdoc />
+    public IObservable<ReactiveIPlcTag?> ObserveAll => _all;
+
+    /// <inheritdoc />
+    public IObservable<ReactiveOmronPLCException?> Errors => _errors;
+
+    /// <inheritdoc />
+    public ReactivePLCType PLCType => ReactivePLCType.Unknown;
+
+    /// <inheritdoc />
+    public string? ControllerModel => null;
+
+    /// <inheritdoc />
+    public string? ControllerVersion => null;
+
+    /// <summary>Gets a value indicating whether this fake PLC is disposed.</summary>
+    public bool IsDisposed { get; private set; }
+
+    /// <inheritdoc />
+    public void AddUpdateTagItem<T>(string variable, string tagName)
+    {
+        Registrations.Add(new(tagName, variable, typeof(T)));
+        _ = GetSubject(tagName);
+    }
+
+    /// <inheritdoc />
+    public IObservable<T?> Observe<T>(string? tagName)
+    {
+        if (tagName is null)
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        return GetSubject(tagName).Select(value => value is null ? default : (T?)value);
+    }
+
+    /// <inheritdoc />
+    public T? Value<T>(string? tagName)
+    {
+        if (tagName is null)
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        return _values.TryGetValue(tagName, out var value) && value is T typed ? typed : default;
+    }
+
+    /// <inheritdoc />
+    public void Value<T>(string? tagName, T? value)
+    {
+        if (tagName is null)
+        {
+            throw new ArgumentNullException(nameof(tagName));
+        }
+
+        Writes.Add(new(tagName, value, typeof(T)));
+        Publish(tagName, value);
+    }
+
+    /// <inheritdoc />
+    public Task<ReactiveReadClockResult> ReadClockAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(default(ReactiveReadClockResult));
+
+    /// <inheritdoc />
+    public Task<ReactiveWriteClockResult> WriteClockAsync(DateTime newDateTime, CancellationToken cancellationToken = default) =>
+        Task.FromResult(default(ReactiveWriteClockResult));
+
+    /// <inheritdoc />
+    public Task<ReactiveWriteClockResult> WriteClockAsync(DateTime newDateTime, int newDayOfWeek, CancellationToken cancellationToken = default) =>
+        Task.FromResult(default(ReactiveWriteClockResult));
+
+    /// <inheritdoc />
+    public Task<ReactiveReadCycleTimeResult> ReadCycleTimeAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(default(ReactiveReadCycleTimeResult));
+
+    /// <summary>Publishes a tag value to observers.</summary>
+    /// <typeparam name="T">The tag value type.</typeparam>
+    /// <param name="tagName">The tag name.</param>
+    /// <param name="value">The tag value.</param>
+    public void Publish<T>(string tagName, T? value)
+    {
+        _values[tagName] = value;
+        GetSubject(tagName).OnNext(value);
+        _all.OnNext(null);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+        foreach (var subject in _subjects.Values)
+        {
+            subject.OnCompleted();
+            subject.Dispose();
+        }
+
+        _all.OnCompleted();
+        _all.Dispose();
+        _errors.OnCompleted();
+        _errors.Dispose();
+    }
+
+    /// <summary>Gets or creates the subject for a tag.</summary>
+    /// <param name="tagName">The tag name.</param>
+    /// <returns>The tag value subject.</returns>
+    private BehaviorSignal<object?> GetSubject(string tagName)
+    {
+        if (_subjects.TryGetValue(tagName, out var subject))
+        {
+            return subject;
+        }
+
+        subject = new(default);
+        _subjects.Add(tagName, subject);
+        return subject;
+    }
+
+    /// <summary>Captures a registered PLC tag.</summary>
+    /// <param name="TagName">The tag name.</param>
+    /// <param name="Address">The PLC address.</param>
+    /// <param name="TagType">The tag value type.</param>
+    public sealed record Registration(string TagName, string Address, Type TagType);
+
+    /// <summary>Captures a PLC tag write.</summary>
+    /// <param name="TagName">The tag name.</param>
+    /// <param name="Value">The written value.</param>
+    /// <param name="TagType">The tag value type.</param>
+    public sealed record Write(string TagName, object? Value, Type TagType);
+}

--- a/tests/OmronPlcRx.Tests/ReactiveGeneratedMachineState.cs
+++ b/tests/OmronPlcRx.Tests/ReactiveGeneratedMachineState.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveBcd16 = global::OmronPlcRx.Reactive.Core.Types.Bcd16;
+
+namespace OmronPlcRx.Reactive.Tests;
+
+/// <summary>Generated reactive PLC tag fixture used by shim tests.</summary>
+public sealed partial class ReactiveGeneratedMachineState
+{
+    /// <summary>Stores the generated tank level tag backing field.</summary>
+    [PlcTag("D100", Writable = true)]
+    private short _tankLevel;
+
+    /// <summary>Stores the generated BCD temperature tag backing field.</summary>
+    [PlcTag("D700")]
+    private ReactiveBcd16 _bcdTemp;
+}

--- a/tests/OmronPlcRx.Tests/ReactiveShimProjectTests.cs
+++ b/tests/OmronPlcRx.Tests/ReactiveShimProjectTests.cs
@@ -1,0 +1,144 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO.Ports;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Async;
+using TUnit.Core;
+using ReactiveBcd16 = global::OmronPlcRx.Reactive.Core.Types.Bcd16;
+using ReactiveOmronSerialOptions = global::OmronPlcRx.Reactive.OmronSerialOptions;
+using ReactiveOmronSerialProtocol = global::OmronPlcRx.Reactive.OmronSerialProtocol;
+
+namespace OmronPlcRx.Reactive.Tests;
+
+/// <summary>Tests the shared-source reactive shim project.</summary>
+public sealed class ReactiveShimProjectTests
+{
+    /// <summary>Verifies generated bindings target the reactive namespace and facade.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ReactiveGeneratedStreams_RegisterBindUpdateAndWriteTags()
+    {
+        var plc = new ReactiveFakeOmronPlcRx();
+        var state = new ReactiveGeneratedMachineState();
+        var observedLevels = new List<short>();
+
+        using var levelSubscription = state.TankLevelObservable.SubscribeSafe(observedLevels.Add, static exception => throw exception);
+        using var binding = state.BindPlcTags(plc);
+
+        plc.Publish("TankLevel", (short)123);
+        plc.Publish("BcdTemp", new ReactiveBcd16(235));
+
+        var asyncValue = await FirstValueAsync(state.TankLevelObservableAsync);
+        state.WriteTankLevel(plc, 456);
+
+        await Assert.That(state.TankLevel).IsEqualTo((short)456);
+        await Assert.That(state.BcdTemp).IsEqualTo(new ReactiveBcd16(235));
+        await Assert.That(asyncValue).IsEqualTo((short)123);
+        await Assert.That(observedLevels.Contains(123)).IsTrue();
+        await Assert.That(HasRegistration(plc.Registrations, "TankLevel", "D100", typeof(short))).IsTrue();
+        await Assert.That(HasRegistration(plc.Registrations, "BcdTemp", "D700", typeof(ReactiveBcd16))).IsTrue();
+        await Assert.That(HasWrite(plc.Writes, "TankLevel", (short)456)).IsTrue();
+    }
+
+    /// <summary>Verifies the reactive project exposes serial settings through the shared source namespace.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ReactiveSerialOptions_CreateToolbusUsesReactiveNamespace()
+    {
+        var options = ReactiveOmronSerialOptions.CreateToolbus("COM3");
+
+        await Assert.That(options.PortName).IsEqualTo("COM3");
+        await Assert.That(options.Protocol).IsEqualTo(ReactiveOmronSerialProtocol.Toolbus);
+        await Assert.That(options.BaudRate).IsEqualTo(115_200);
+        await Assert.That(options.DataBits).IsEqualTo(8);
+        await Assert.That(options.Parity).IsEqualTo(Parity.None);
+        await Assert.That(options.StopBits).IsEqualTo(StopBits.One);
+        await Assert.That(options.MaximumFrameLength).IsEqualTo(1004);
+    }
+
+    /// <summary>Gets the first value published by an async observable.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    /// <param name="source">The async observable source.</param>
+    /// <returns>The first observed value.</returns>
+    private static async Task<T> FirstValueAsync<T>(IObservableAsync<T> source)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var observer = new FirstValueObserver<T>();
+        await using var subscription = await source.SubscribeAsync(observer, timeout.Token).ConfigureAwait(false);
+        return await observer.Task.WaitAsync(timeout.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>Checks whether a registration was captured.</summary>
+    /// <param name="registrations">The captured registrations.</param>
+    /// <param name="tagName">The expected tag name.</param>
+    /// <param name="address">The expected PLC address.</param>
+    /// <param name="tagType">The expected tag type.</param>
+    /// <returns><see langword="true"/> when the registration was found.</returns>
+    private static bool HasRegistration(IEnumerable<ReactiveFakeOmronPlcRx.Registration> registrations, string tagName, string address, Type tagType)
+    {
+        foreach (var registration in registrations)
+        {
+            if (registration.TagName == tagName && registration.Address == address && registration.TagType == tagType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Checks whether a write was captured.</summary>
+    /// <param name="writes">The captured writes.</param>
+    /// <param name="tagName">The expected tag name.</param>
+    /// <param name="value">The expected written value.</param>
+    /// <returns><see langword="true"/> when the write was found.</returns>
+    private static bool HasWrite(IEnumerable<ReactiveFakeOmronPlcRx.Write> writes, string tagName, object value)
+    {
+        foreach (var write in writes)
+        {
+            if (write.TagName == tagName && Equals(write.Value, value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Observer that completes after the first async observable value.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class FirstValueObserver<T> : IObserverAsync<T>
+    {
+        /// <summary>Completes when the first value, error, or completion arrives.</summary>
+        private readonly TaskCompletionSource<T> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Gets the completion task.</summary>
+        public Task<T> Task => _completion.Task;
+
+        /// <inheritdoc />
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        /// <inheritdoc />
+        public ValueTask OnCompletedAsync(Result result)
+        {
+            _ = _completion.TrySetException(new InvalidOperationException("The async observable completed without a value."));
+            return ValueTask.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken)
+        {
+            _ = _completion.TrySetException(error);
+            return ValueTask.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public ValueTask OnNextAsync(T value, CancellationToken cancellationToken)
+        {
+            _ = _completion.TrySetResult(value);
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature and test coverage update.

## What is the new behavior?

Adds `OmronPlcRx.Reactive` as a shared-source package that compiles the existing `OmronPlcRx` code under `REACTIVE_SHIM`, uses `SerialPortRx.Reactive`, and switches namespaces/usings between `OmronPlcRx.*` and `OmronPlcRx.Reactive.*`.

The source generator now supports reactive attributes and generated targets, and the test project includes focused TUnit coverage for protocol codecs, value parsing, socket wrappers, channel behavior, connection validation, and reactive shim compilation. Coverage settings exclude tests, examples, bin/obj output, and the duplicate linked reactive assembly.

## What is the current behavior?

Only the canonical `OmronPlcRx` package exists. There is no `OmronPlcRx.Reactive` package variant, and generated PLC tag code does not target the reactive namespace/package shape.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows Conventional Commits

## Additional information

Verification completed locally:

- `dotnet build src\OmronPlcRx.sln -c Debug -v minimal`
- `dotnet test tests\OmronPlcRx.Tests\OmronPlcRx.Tests.csproj -c Debug --coverage --coverage-output coverage.cobertura.xml --coverage-output-format cobertura --coverage-settings CodeCoverage.settings.xml --results-directory artifacts\coverage --verbosity minimal`

Result: 51/51 tests passed. Cobertura summary for the included canonical assembly: 58.86% line coverage (1846/3136) and 44.81% branch coverage (479/1069).

Note: two existing dashboard file edits are intentionally not included in this PR because they were unrelated to the reactive/shared-source package work.